### PR TITLE
Add wildcard support for data source file paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,11 +80,12 @@ currency_format: "€{amount}"  # Optional: €1,234 or "{amount} zł" for 1,234
 
 data_sources:
   - name: AMEX
-    file: data/amex.csv
+    file: data/amex.csv        # Single file
     account_type: credit_card
     format: "{date:%m/%d/%Y},{description},{amount}"
+  # Use glob patterns to match multiple files:
   - name: Chase
-    file: data/chase.csv
+    file: data/chase*.csv      # Matches chase-2024.csv, chase-2025.csv, etc.
     account_type: credit_card
     format: "{date:%m/%d/%Y},{description},{amount}"
   - name: BofA Checking
@@ -97,6 +98,8 @@ data_sources:
     format: "{date:%d.%m.%Y},{description},{amount}"
     decimal_separator: ","  # European format (1.234,56)
 ```
+
+**File Patterns**: The `file` parameter supports glob patterns (`*`, `?`, `[]`) to match multiple files. Files are processed in sorted order.
 
 ### Account Types
 

--- a/config/settings.yaml.example
+++ b/config/settings.yaml.example
@@ -15,10 +15,15 @@ title: "Spending Analysis"
 
 # Data sources - list of transaction files to process
 # Paths are relative to the parent of the config directory
+# Supports glob patterns (*, ?, []) to match multiple files
 data_sources:
   - name: AMEX
-    file: data/amex-2025.csv
+    file: data/amex-2025.csv      # Single file
     type: amex
+  # Example with glob pattern to match multiple files:
+  # - name: AMEX
+  #   file: data/amex*.csv        # Matches amex-2024.csv, amex-2025.csv, etc.
+  #   type: amex
   - name: BOA
     file: data/boa-checking.txt
     type: boa

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -7,6 +7,169 @@ import os
 from pathlib import Path
 
 
+class TestGlobPatternSupport:
+    """Tests for wildcard/glob pattern support in data source file paths."""
+
+    def test_glob_pattern_matches_multiple_files(self):
+        """Glob pattern should match multiple CSV files."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config_dir = os.path.join(tmpdir, 'config')
+            data_dir = os.path.join(tmpdir, 'data')
+            os.makedirs(config_dir)
+            os.makedirs(data_dir)
+
+            # Create settings with glob pattern
+            with open(os.path.join(config_dir, 'settings.yaml'), 'w') as f:
+                f.write("""year: 2025
+data_sources:
+  - name: TestBank
+    file: data/test*.csv
+    format: "{date:%Y-%m-%d},{description},{amount}"
+""")
+
+            # Create multiple matching files
+            with open(os.path.join(data_dir, 'test-jan.csv'), 'w') as f:
+                f.write("date,description,amount\n")
+                f.write("2025-01-15,NETFLIX,-15.99\n")
+
+            with open(os.path.join(data_dir, 'test-feb.csv'), 'w') as f:
+                f.write("date,description,amount\n")
+                f.write("2025-02-15,SPOTIFY,-9.99\n")
+
+            result = subprocess.run(
+                ['uv', 'run', 'tally', 'run', '--format', 'summary', config_dir],
+                capture_output=True,
+                text=True
+            )
+            assert result.returncode == 0
+            # Should report transactions from 2 files
+            assert '2 files' in result.stdout
+            assert '2 transactions' in result.stdout
+
+    def test_glob_pattern_single_file_fallback(self):
+        """Single file path (no wildcards) should still work."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config_dir = os.path.join(tmpdir, 'config')
+            data_dir = os.path.join(tmpdir, 'data')
+            os.makedirs(config_dir)
+            os.makedirs(data_dir)
+
+            with open(os.path.join(config_dir, 'settings.yaml'), 'w') as f:
+                f.write("""year: 2025
+data_sources:
+  - name: TestBank
+    file: data/transactions.csv
+    format: "{date:%Y-%m-%d},{description},{amount}"
+""")
+
+            with open(os.path.join(data_dir, 'transactions.csv'), 'w') as f:
+                f.write("date,description,amount\n")
+                f.write("2025-01-15,TEST,-10.00\n")
+
+            result = subprocess.run(
+                ['uv', 'run', 'tally', 'run', '--format', 'summary', config_dir],
+                capture_output=True,
+                text=True
+            )
+            assert result.returncode == 0
+            assert '1 file' in result.stdout
+            assert '1 transactions' in result.stdout
+
+    def test_glob_pattern_no_matches_shows_error(self):
+        """Glob pattern with no matches should show helpful message."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config_dir = os.path.join(tmpdir, 'config')
+            data_dir = os.path.join(tmpdir, 'data')
+            os.makedirs(config_dir)
+            os.makedirs(data_dir)
+
+            with open(os.path.join(config_dir, 'settings.yaml'), 'w') as f:
+                f.write("""year: 2025
+data_sources:
+  - name: TestBank
+    file: data/nonexistent*.csv
+    format: "{date:%Y-%m-%d},{description},{amount}"
+""")
+
+            result = subprocess.run(
+                ['uv', 'run', 'tally', 'run', '--format', 'summary', config_dir],
+                capture_output=True,
+                text=True
+            )
+            # Should show "No files found matching pattern"
+            assert 'No files found matching pattern' in result.stdout
+
+    def test_glob_diag_shows_matched_files(self):
+        """Diag command should show matched files for glob patterns."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config_dir = os.path.join(tmpdir, 'config')
+            data_dir = os.path.join(tmpdir, 'data')
+            os.makedirs(config_dir)
+            os.makedirs(data_dir)
+
+            with open(os.path.join(config_dir, 'settings.yaml'), 'w') as f:
+                f.write("""year: 2025
+data_sources:
+  - name: TestBank
+    file: data/test*.csv
+    format: "{date:%Y-%m-%d},{description},{amount}"
+""")
+
+            # Create multiple matching files
+            with open(os.path.join(data_dir, 'test-a.csv'), 'w') as f:
+                f.write("date,description,amount\n")
+
+            with open(os.path.join(data_dir, 'test-b.csv'), 'w') as f:
+                f.write("date,description,amount\n")
+
+            result = subprocess.run(
+                ['uv', 'run', 'tally', 'diag', config_dir],
+                capture_output=True,
+                text=True
+            )
+            assert result.returncode == 0
+            # Should show pattern and matched files
+            assert 'Pattern:' in result.stdout or 'data/test*.csv' in result.stdout
+            assert 'Matched files: 2' in result.stdout
+            assert 'test-a.csv' in result.stdout
+            assert 'test-b.csv' in result.stdout
+
+    def test_glob_files_processed_in_sorted_order(self):
+        """Files should be processed in sorted order for consistency."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config_dir = os.path.join(tmpdir, 'config')
+            data_dir = os.path.join(tmpdir, 'data')
+            os.makedirs(config_dir)
+            os.makedirs(data_dir)
+
+            with open(os.path.join(config_dir, 'settings.yaml'), 'w') as f:
+                f.write("""year: 2025
+data_sources:
+  - name: TestBank
+    file: data/*.csv
+    format: "{date:%Y-%m-%d},{description},{amount}"
+""")
+
+            # Create files in non-alphabetical order
+            with open(os.path.join(data_dir, 'z-last.csv'), 'w') as f:
+                f.write("date,description,amount\n")
+                f.write("2025-01-01,Z_FIRST,-1.00\n")
+
+            with open(os.path.join(data_dir, 'a-first.csv'), 'w') as f:
+                f.write("date,description,amount\n")
+                f.write("2025-01-01,A_FIRST,-1.00\n")
+
+            result = subprocess.run(
+                ['uv', 'run', 'tally', 'diag', config_dir],
+                capture_output=True,
+                text=True
+            )
+            # a-first.csv should appear before z-last.csv in diag output
+            a_pos = result.stdout.find('a-first.csv')
+            z_pos = result.stdout.find('z-last.csv')
+            assert a_pos < z_pos, "Files should be listed in sorted order"
+
+
 class TestCLIErrorHandling:
     """Tests for helpful error messages when CLI is misused."""
 


### PR DESCRIPTION
## Summary
Adds support for glob patterns in data source file paths, allowing users to match multiple files with a single configuration entry.

Based on PR #44 by @vechiato, with added tests for cross-platform verification.

## Changes
- Added `_expand_file_pattern()` function to handle wildcard patterns (`*`, `?`, `[]`)
- Updated `cmd_run()`, `cmd_discover()`, `cmd_explain()`, and `cmd_diag()` to process multiple matched files
- Files are processed in sorted order for consistency
- Improved error messages to show pattern matching results
- Updated documentation with wildcard examples in README.md and settings.yaml.example
- **Added comprehensive tests** for glob pattern functionality

## Example Usage
```yaml
data_sources:
  - name: AMEX
    file: data/amex*.csv      # Matches amex-2024.csv, amex-2025.csv, etc.
    account_type: credit_card
    format: "{date:%m/%d/%Y},{description},{amount}"
```

## Test Plan
- [x] Glob pattern matches multiple files
- [x] Single file path (no wildcards) still works
- [x] No matches shows helpful error message
- [x] Diag command shows matched files
- [x] Files processed in sorted order

Closes #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)