### PR TITLE
Move documentation from README to website

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,26 +1,17 @@
 # Tally
 
-**A local rule engine for transaction classification.** Pair it with an LLM to eliminate the manual work.
+**A local rule engine for transaction classification.** Pair it with an AI assistant to eliminate the manual work.
 
-Works with Claude Code, Codex, Copilot, Cursor, or a local model.
-
-👉 **[Website](https://tallyai.money)** · **[Releases](https://github.com/davidfowl/tally/releases)**
+Works with Claude Code, Codex, Copilot, Cursor, or any command-line AI agent.
 
 ## Install
 
-**Linux/macOS:**
 ```bash
+# Linux/macOS
 curl -fsSL https://tallyai.money/install.sh | bash
-```
 
-**Windows PowerShell:**
-```powershell
+# Windows PowerShell
 irm https://tallyai.money/install.ps1 | iex
-```
-
-**With uv:**
-```bash
-uv tool install git+https://github.com/davidfowl/tally
 ```
 
 ## Quick Start
@@ -31,363 +22,28 @@ cd my-budget
 tally workflow              # See next steps
 ```
 
+Tell your AI assistant: *"Use tally to categorize my transactions"*
+
+## Documentation
+
+Full documentation is available at **[tallyai.money](https://tallyai.money)**:
+
+- [Quick Start](https://tallyai.money/quickstart.html) - Get running in 5 minutes
+- [Guide](https://tallyai.money/guide.html) - Using Tally with AI assistants
+- [Reference](https://tallyai.money/reference.html) - merchants.rules and views.rules syntax
+- [Formats](https://tallyai.money/formats.html) - settings.yaml and CSV format strings
+
 ## Commands
 
 | Command | Description |
 |---------|-------------|
-| `tally init [dir]` | Set up a new budget folder |
-| `tally workflow` | Show next steps (detects setup state, unknown merchants) |
-| `tally run` | Parse transactions and generate HTML report |
-| `tally run --format json` | Output analysis as JSON with reasoning |
-| `tally explain` | Explain why merchants are classified the way they are |
-| `tally explain <merchant>` | Explain specific merchant's classification |
-| `tally discover` | Find uncategorized transactions (`--format json` for LLMs) |
-| `tally inspect <csv>` | Show CSV structure to build format string |
-| `tally diag` | Debug config issues |
-| `tally version` | Show version and check for updates |
-| `tally update` | Update to latest version |
-
-### Output Formats
-
-Both `tally run` and `tally explain` support multiple output formats:
-
-```bash
-tally run --format json        # JSON with classification reasoning
-tally run --format markdown    # Markdown report
-tally run --format summary     # Text summary only
-tally run -v                   # Verbose: include decision trace
-tally run -vv                  # Very verbose: include thresholds, CV values
-```
-
-### Filtering
-
-Filter output to specific classifications or categories:
-
-```bash
-tally run --format json --only monthly,variable   # Just these classifications
-tally run --format json --category Food           # Just Food category
-tally explain --classification monthly            # Explain all monthly merchants
-tally explain --category Subscriptions            # Explain all subscriptions
-```
-
-## Configuration
-
-### settings.yaml
-
-```yaml
-year: 2025
-currency_format: "€{amount}"  # Optional: €1,234 or "{amount} zł" for 1,234 zł
-
-data_sources:
-  - name: AMEX
-    file: data/amex.csv
-    account_type: credit_card
-    format: "{date:%m/%d/%Y},{description},{amount}"
-  - name: Chase
-    file: data/chase.csv
-    account_type: credit_card
-    format: "{date:%m/%d/%Y},{description},{amount}"
-  - name: BofA Checking
-    file: data/bofa.csv
-    account_type: bank
-    format: "{date:%m/%d/%Y},{description},{amount}"
-  - name: German Bank
-    file: data/german.csv
-    account_type: bank
-    format: "{date:%d.%m.%Y},{description},{amount}"
-    decimal_separator: ","  # European format (1.234,56)
-```
-
-### Account Types
-
-Use `account_type` to automatically handle sign conventions:
-
-| Type | Behavior | Use For |
-|------|----------|---------|
-| `credit_card` | Keep signs as-is | Credit cards (charges positive, payments negative) |
-| `bank` | Negate amounts, skip credits | Checking/savings (debits negative, deposits positive) |
-| `brokerage` | Same as bank | Investment accounts |
-
-The `account_type` sets sensible defaults that can be overridden:
-- `negate_amount`: Flip the sign of amounts
-- `skip_negative`: Skip negative amounts after negation (filters income/deposits)
-
-Run `tally inspect <file>` to see suggested account type based on your data.
-
-### Format Strings
-
-| Token | Description |
-|-------|-------------|
-| `{date:%m/%d/%Y}` | Date with format |
-| `{description}` | Transaction description |
-| `{amount}` | Amount column |
-| `{_}` | Skip column |
-| `{custom_name}` | Capture column for use in description template |
-
-> **Note:** Use `account_type` instead of `{-amount}` for sign handling. The `{-amount}` syntax is deprecated.
-
-**Multi-column descriptions** - Some banks split info across columns:
-```yaml
-- name: European Bank
-  file: data/bank.csv
-  format: "{date:%d.%m.%Y},{_},{txn_type},{vendor},{_},{amount}"
-  columns:
-    description: "{vendor} ({txn_type})"  # Combines into "STORE NAME (Card payment)"
-```
-
-### Merchant Rules
-
-#### merchants.rules (Recommended)
-
-Expression-based rules with full power:
-
-```yaml
-# settings.yaml
-merchants_file: config/merchants.rules
-```
-
-```python
-# config/merchants.rules
-
-# Variables for reuse
-is_large = amount > 200
-is_holiday = month >= 11 and month <= 12
-
-[Netflix]
-match: contains("NETFLIX")
-category: Subscriptions
-subcategory: Streaming
-tags: entertainment, recurring
-
-[Uber Rides]
-match: regex("UBER(?!.*EATS)")
-category: Transportation
-subcategory: Rideshare
-
-[Uber Eats]
-match: contains("UBER") and contains("EATS")
-category: Food
-subcategory: Delivery
-
-[Costco Grocery]
-match: contains("COSTCO") and amount <= 200
-category: Food
-subcategory: Grocery
-
-[Costco Bulk]
-match: contains("COSTCO") and is_large
-category: Shopping
-subcategory: Wholesale
-
-[Holiday Gift]
-match: contains("AMAZON") and is_holiday and amount > 100
-category: Shopping
-subcategory: Gifts
-tags: holiday
-```
-
-**Match expressions:**
-| Function | Description |
-|----------|-------------|
-| `contains("X")` | Case-insensitive substring match |
-| `regex("pattern")` | Regex pattern match |
-| `amount > 100` | Amount conditions |
-| `month == 12` | Date component (month, year, day) |
-| `date >= "2025-11-28"` | Date range |
-| `field.location` | Transaction location (from CSV) |
-| `field.memo`, etc. | Custom fields captured from CSV |
-
-**Field transforms** - Strip prefixes before matching:
-```python
-# At the top of merchants.rules
-field.description = regex_replace(field.description, "^APLPAY\\s+", "")
-field.description = regex_replace(field.description, "^SQ\\s*\\*", "")
-```
-
-Functions: `regex_replace()`, `uppercase()`, `lowercase()`, `strip_prefix()`, `strip_suffix()`, `trim()`
-
-Run `tally reference` for full documentation.
-
-**Two-pass evaluation:**
-1. **Categorization**: First matching rule with `category:` wins
-2. **Tagging**: ALL matching rules contribute their tags (additive)
-
-This allows tag-only rules that apply across categories:
-```python
-[Large Purchase]
-match: amount > 500
-tags: large
-
-[Holiday Season]
-match: month >= 11 and month <= 12
-tags: holiday
-```
-
-#### merchant_categories.csv (Deprecated)
-
-Legacy CSV format still works but will show a migration prompt:
-
-```csv
-Pattern,Merchant,Category,Subcategory,Tags
-WHOLEFDS,Whole Foods,Food,Grocery,
-NETFLIX,Netflix,Subscriptions,Streaming,entertainment|recurring
-COSTCO[amount>200],Costco Bulk,Shopping,Bulk,
-```
-
-Run `tally run` to migrate to the new format.
-
-**Tags** are optional, comma-separated labels for filtering:
-- Use cases: `business`, `reimbursable`, `entertainment`, `recurring`, `tax-deductible`
-- Filter in UI: Click tag badges or type `t:business` in search
-- Filter in CLI: `tally explain --tags business,reimbursable`
-
-### views.rules (Optional)
-
-Define custom views using filter expressions. Create `config/views.rules`:
-
-```
-[Every Month]
-description: Consistent recurring (rent, utilities, subscriptions)
-filter: months >= 6 and cv < 0.3
-
-[Variable Recurring]
-description: Frequent but inconsistent (groceries, shopping)
-filter: months >= 6 and cv >= 0.3
-
-[Periodic]
-description: Quarterly or semi-annual (tuition, insurance)
-filter: months >= 2 and months <= 5
-
-[Large Purchases]
-description: Big one-time expenses
-filter: total > 1000 and months <= 2
-
-[Tagged: Business]
-description: Business expenses
-filter: "business" in tags
-```
-
-**Primitives:**
-| Name | Type | Description |
-|------|------|-------------|
-| `months` | int | Unique months with transactions |
-| `total` | float | Sum of all payments |
-| `cv` | float | Coefficient of variation (0 = consistent, >0.3 = variable) |
-| `category` | str | Category (e.g., "Food") |
-| `subcategory` | str | Subcategory (e.g., "Grocery") |
-| `tags` | set | Tag strings from merchant rules |
-| `payments` | list | All payment amounts |
-
-**Functions:**
-| Function | Description |
-|----------|-------------|
-| `sum(x)`, `avg(x)`, `count(x)` | Aggregation functions |
-| `min(x)`, `max(x)`, `stddev(x)` | Statistical functions |
-| `abs(x)`, `round(x)` | Math functions |
-| `by(field)` | Group payments by field (month, year, week, day) |
-| `period(field)` | Total analysis period (e.g., `period("month")` = 12 for full year) |
-| `max_val(a, b)`, `min_val(a, b)` | Scalar max/min for threshold calculations |
-
-**Grouping with `by()`:**
-
-The `by()` function groups payments by time period. Aggregation functions auto-map over groups:
-```
-by("month")              # [[100, 200], [150], [175, 125]] - grouped payments
-sum(by("month"))         # [300, 150, 300] - monthly totals
-avg(sum(by("month")))    # 250 - average monthly spend
-max(sum(by("month")))    # 300 - highest spending month
-```
-
-**Using variables for complex filters:**
-```
-# Global variables
-monthly = sum(by("month"))
-my_cv = stddev(monthly) / avg(monthly)
-peak_ratio = max(monthly) / avg(monthly)
-
-[Spiky Spending]
-description: Months with unusually high spending
-filter: peak_ratio > 2
-
-[Consistent]
-filter: my_cv < 0.3
-```
-
-**Proportional thresholds with `period()` and `max_val()`:**
-```
-# Thresholds that adapt to partial-year analysis
-bill_threshold = max_val(2, period("month") * 0.5)    # 50% of months, min 2
-general_threshold = max_val(3, period("month") * 0.75) # 75% of months, min 3
-
-[Monthly Bills]
-filter: category == "Bills" and months >= bill_threshold
-
-[Frequent Spending]
-filter: months >= general_threshold
-```
-
-**Advanced filter examples:**
-```
-# High-value inconsistent spending
-filter: total > 5000 and cv >= 0.5
-
-# Subscription-like (consistent, 6+ months)
-filter: cv < 0.2 and months >= 6 and avg(payments) < 100
-
-# Large single transactions
-filter: max(payments) > 2000 and count(payments) <= 3
-
-# Specific categories with thresholds
-filter: category == "Food" and total > 500 and months >= 3
-
-# Tag-based with amount filter
-filter: "recurring" in tags and avg(payments) > 50
-
-# Monthly analysis
-filter: max(sum(by("month"))) > 1000
-```
-
-Views can overlap - the same merchant can appear in multiple views.
-
-## For AI Agents
-
-Run `tally workflow` at any time to see context-aware instructions:
-
-```bash
-tally workflow    # Shows next steps based on current state
-```
-
-The workflow command detects your setup state and shows relevant instructions:
-- No config? → How to initialize
-- No data sources? → How to configure them
-- Unknown merchants? → Categorization workflow
-
-**Key commands for agents:**
-- `tally discover --format json` - Get unknown merchants with suggested patterns
-- `tally run --format json -v` - Full analysis with classification reasoning
-- `tally explain <merchant> -vv` - Why a merchant is classified (with rule info)
-- `tally diag --format json` - Debug configuration issues
-
-## Development Builds
-
-Get the latest build from main branch:
-
-**Update existing install:**
-```bash
-tally update --prerelease
-```
-
-**Fresh install (Linux/macOS):**
-```bash
-curl -fsSL https://tallyai.money/install.sh | bash -s -- --prerelease
-```
-
-**Fresh install (Windows):**
-```powershell
-iex "& { $(irm https://tallyai.money/install.ps1) } -Prerelease"
-```
-
-Dev builds are created automatically on every push to main. When running a dev version, `tally version` will notify you of newer dev builds.
+| `tally init` | Create a new budget folder |
+| `tally workflow` | Show context-aware next steps |
+| `tally run` | Generate HTML spending report |
+| `tally discover` | Find uncategorized transactions |
+| `tally explain` | Explain merchant classifications |
+| `tally inspect` | Analyze CSV structure |
+| `tally reference` | Show full syntax reference |
 
 ## License
 

--- a/docs/formats.html
+++ b/docs/formats.html
@@ -1,0 +1,667 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Formats - Tally</title>
+    <meta name="description" content="Tally configuration file formats. settings.yaml structure, data source format strings, and account types.">
+    <link rel="icon" type="image/svg+xml" href="logo.svg">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=JetBrains+Mono&display=swap" rel="stylesheet">
+    <style>
+        * { box-sizing: border-box; margin: 0; padding: 0; }
+
+        body {
+            font-family: 'Inter', -apple-system, sans-serif;
+            background: linear-gradient(135deg, #0a1f0a 0%, #0d2818 50%, #061a12 100%);
+            color: #fff;
+            min-height: 100vh;
+            line-height: 1.6;
+        }
+
+        nav {
+            background: rgba(0,0,0,0.3);
+            border-bottom: 1px solid rgba(255,255,255,0.08);
+            padding: 1rem 2rem;
+            position: sticky;
+            top: 0;
+            z-index: 100;
+            backdrop-filter: blur(10px);
+        }
+
+        nav .nav-inner {
+            max-width: 1100px;
+            margin: 0 auto;
+            display: flex;
+            align-items: center;
+            gap: 2rem;
+        }
+
+        nav .nav-logo {
+            font-family: 'JetBrains Mono', monospace;
+            font-size: 1.25rem;
+            font-weight: 600;
+            color: #4ade80;
+            text-decoration: none;
+            display: flex;
+            align-items: center;
+            gap: 0.5rem;
+        }
+
+        nav .nav-logo img {
+            width: 1.5rem;
+            height: 1.5rem;
+        }
+
+        nav .nav-links {
+            display: flex;
+            gap: 1.5rem;
+            flex: 1;
+        }
+
+        nav .nav-links a {
+            color: rgba(255,255,255,0.6);
+            text-decoration: none;
+            font-size: 0.9rem;
+            transition: color 0.2s;
+        }
+
+        nav .nav-links a:hover,
+        nav .nav-links a.active {
+            color: #4ade80;
+        }
+
+        nav .nav-github {
+            color: rgba(255,255,255,0.6);
+            text-decoration: none;
+            font-size: 0.9rem;
+            transition: color 0.2s;
+        }
+
+        nav .nav-github:hover {
+            color: #4ade80;
+        }
+
+        .container {
+            max-width: 900px;
+            margin: 0 auto;
+            padding: 3rem 2rem 5rem;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            font-weight: 600;
+            margin-bottom: 0.5rem;
+            background: linear-gradient(135deg, #4ade80 0%, #22c55e 50%, #16a34a 100%);
+            -webkit-background-clip: text;
+            -webkit-text-fill-color: transparent;
+            background-clip: text;
+        }
+
+        .subtitle {
+            color: rgba(255,255,255,0.6);
+            font-size: 1.1rem;
+            margin-bottom: 2rem;
+        }
+
+        .toc {
+            background: rgba(255,255,255,0.03);
+            border: 1px solid rgba(255,255,255,0.08);
+            border-radius: 12px;
+            padding: 1.5rem;
+            margin-bottom: 3rem;
+        }
+
+        .toc-title {
+            font-size: 0.8rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.1em;
+            color: rgba(255,255,255,0.5);
+            margin-bottom: 1rem;
+        }
+
+        .toc a {
+            color: rgba(255,255,255,0.7);
+            text-decoration: none;
+            font-size: 0.9rem;
+            display: block;
+            padding: 0.25rem 0;
+        }
+
+        .toc a:hover {
+            color: #4ade80;
+        }
+
+        h2 {
+            font-size: 1.5rem;
+            font-weight: 600;
+            color: #fff;
+            margin: 3rem 0 1rem;
+            padding-top: 1rem;
+            border-top: 1px solid rgba(255,255,255,0.08);
+        }
+
+        h2:first-of-type {
+            margin-top: 0;
+            border-top: none;
+            padding-top: 0;
+        }
+
+        h3 {
+            font-size: 1.1rem;
+            font-weight: 600;
+            color: rgba(255,255,255,0.95);
+            margin: 2rem 0 0.75rem;
+        }
+
+        p {
+            color: rgba(255,255,255,0.8);
+            margin-bottom: 1rem;
+        }
+
+        pre {
+            background: #0d0d0d;
+            border: 1px solid rgba(255,255,255,0.1);
+            border-radius: 8px;
+            padding: 1rem 1.25rem;
+            overflow-x: auto;
+            margin: 1rem 0 1.5rem;
+        }
+
+        code {
+            font-family: 'JetBrains Mono', monospace;
+            font-size: 0.85rem;
+        }
+
+        pre code {
+            color: #e0e0e0;
+        }
+
+        p code {
+            background: rgba(255,255,255,0.1);
+            padding: 0.15rem 0.4rem;
+            border-radius: 4px;
+            font-size: 0.85rem;
+        }
+
+        .comment {
+            color: rgba(255,255,255,0.4);
+        }
+
+        .highlight {
+            color: #4ade80;
+        }
+
+        .keyword {
+            color: #60a5fa;
+        }
+
+        .string {
+            color: #fbbf24;
+        }
+
+        table {
+            width: 100%;
+            border-collapse: collapse;
+            margin: 1rem 0 1.5rem;
+            font-size: 0.9rem;
+        }
+
+        th, td {
+            text-align: left;
+            padding: 0.75rem 1rem;
+            border-bottom: 1px solid rgba(255,255,255,0.08);
+        }
+
+        th {
+            color: rgba(255,255,255,0.5);
+            font-weight: 500;
+            font-size: 0.8rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+        }
+
+        td {
+            color: rgba(255,255,255,0.8);
+        }
+
+        td code {
+            background: rgba(255,255,255,0.08);
+            padding: 0.2rem 0.4rem;
+            border-radius: 4px;
+            font-size: 0.8rem;
+        }
+
+        ul, ol {
+            margin: 1rem 0 1.5rem 1.5rem;
+            color: rgba(255,255,255,0.8);
+        }
+
+        li {
+            margin-bottom: 0.5rem;
+        }
+
+        a {
+            color: #4ade80;
+            text-decoration: none;
+        }
+
+        a:hover {
+            text-decoration: underline;
+        }
+
+        .note {
+            background: rgba(96, 165, 250, 0.1);
+            border: 1px solid rgba(96, 165, 250, 0.2);
+            border-radius: 8px;
+            padding: 1rem 1.25rem;
+            margin: 1rem 0 1.5rem;
+            font-size: 0.9rem;
+        }
+
+        .note-title {
+            color: #60a5fa;
+            font-weight: 600;
+            margin-bottom: 0.5rem;
+        }
+
+        .note p {
+            margin-bottom: 0;
+        }
+
+        .tip {
+            background: rgba(74, 222, 128, 0.1);
+            border: 1px solid rgba(74, 222, 128, 0.2);
+            border-radius: 8px;
+            padding: 1rem 1.25rem;
+            margin: 1rem 0 1.5rem;
+            font-size: 0.9rem;
+        }
+
+        .tip-title {
+            color: #4ade80;
+            font-weight: 600;
+            margin-bottom: 0.5rem;
+        }
+
+        .tip p {
+            margin-bottom: 0;
+        }
+
+        @media (max-width: 768px) {
+            nav .nav-inner {
+                flex-wrap: wrap;
+                gap: 1rem;
+            }
+            nav .nav-links {
+                order: 3;
+                width: 100%;
+                flex-wrap: wrap;
+                gap: 1rem;
+            }
+            h1 { font-size: 2rem; }
+            .container { padding: 2rem 1.5rem 3rem; }
+            table { font-size: 0.8rem; }
+            th, td { padding: 0.5rem; }
+        }
+    </style>
+</head>
+<body>
+    <nav>
+        <div class="nav-inner">
+            <a href="index.html" class="nav-logo"><img src="logo.svg" alt="Tally">tally</a>
+            <div class="nav-links">
+                <a href="quickstart.html">Quick Start</a>
+                <a href="guide.html">Guide</a>
+                <a href="reference.html">Reference</a>
+                <a href="formats.html" class="active">Formats</a>
+            </div>
+            <a href="https://github.com/davidfowl/tally" class="nav-github">GitHub</a>
+        </div>
+    </nav>
+
+    <div class="container">
+        <h1>Formats</h1>
+        <p class="subtitle">Configuration file structure and syntax</p>
+
+        <div class="toc">
+            <div class="toc-title">Contents</div>
+            <a href="#settings-yaml">settings.yaml</a>
+            <a href="#data-sources">Data Sources</a>
+            <a href="#format-strings">Format Strings</a>
+            <a href="#date-formats">Date Formats</a>
+            <a href="#currency">Currency Format</a>
+            <a href="#travel">Travel Detection</a>
+            <a href="#commands">CLI Commands</a>
+        </div>
+
+        <h2 id="settings-yaml">settings.yaml</h2>
+        <p>The main configuration file. Created by <code>tally init</code>.</p>
+
+        <pre><code><span class="highlight">year:</span> 2025
+
+<span class="highlight">currency_format:</span> <span class="string">"${amount}"</span>  <span class="comment"># Optional: defaults to $</span>
+
+<span class="highlight">merchants_file:</span> config/merchants.rules
+<span class="highlight">views_file:</span> config/views.rules    <span class="comment"># Optional: custom report sections</span>
+
+<span class="highlight">data_sources:</span>
+  - <span class="highlight">name:</span> Chase
+    <span class="highlight">file:</span> data/chase.csv
+    <span class="highlight">format:</span> <span class="string">"{date:%m/%d/%Y},{description},{amount}"</span>
+
+  - <span class="highlight">name:</span> Bank of America
+    <span class="highlight">file:</span> data/bofa.csv
+    <span class="highlight">format:</span> <span class="string">"{date:%m/%d/%Y},{description},{amount}"</span></code></pre>
+
+        <h2 id="data-sources">Data Sources</h2>
+        <p>Each data source represents a CSV file from a bank or credit card.</p>
+
+        <table>
+            <tr>
+                <th>Field</th>
+                <th>Required</th>
+                <th>Description</th>
+            </tr>
+            <tr>
+                <td><code>name</code></td>
+                <td>Yes</td>
+                <td>Display name (e.g., "Chase", "AMEX Gold")</td>
+            </tr>
+            <tr>
+                <td><code>file</code></td>
+                <td>Yes</td>
+                <td>Path to CSV file (relative or absolute)</td>
+            </tr>
+            <tr>
+                <td><code>format</code></td>
+                <td>Yes</td>
+                <td>Format string describing CSV columns</td>
+            </tr>
+            <tr>
+                <td><code>decimal_separator</code></td>
+                <td>No</td>
+                <td>For European format: <code>","</code> (1.234,56)</td>
+            </tr>
+            <tr>
+                <td><code>columns</code></td>
+                <td>No</td>
+                <td>Custom column mappings (see Format Strings)</td>
+            </tr>
+            <tr>
+                <td><code>delimiter</code></td>
+                <td>No</td>
+                <td>Column delimiter: <code>tab</code>, <code>whitespace</code>, or <code>regex:pattern</code></td>
+            </tr>
+            <tr>
+                <td><code>has_header</code></td>
+                <td>No</td>
+                <td>Set to <code>false</code> if file has no header row</td>
+            </tr>
+        </table>
+
+        <h3>Non-CSV Files</h3>
+        <p>For tab-separated, whitespace-delimited, or fixed-width formats, use the <code>delimiter</code> option:</p>
+        <pre><code><span class="comment"># Tab-separated file</span>
+<span class="highlight">- name:</span> Bank Statement
+  <span class="highlight">file:</span> data/stmt.tsv
+  <span class="highlight">delimiter:</span> tab
+  <span class="highlight">format:</span> <span class="string">"{date:%m/%d/%Y},{description},{amount}"</span>
+
+<span class="comment"># Fixed-width with regex capture groups</span>
+<span class="highlight">- name:</span> BOA Statement
+  <span class="highlight">file:</span> data/stmt.txt
+  <span class="highlight">delimiter:</span> <span class="string">"regex:^(\\d{2}/\\d{2}/\\d{4})\\s+(.+?)\\s+([-\\d,]+\\.\\d{2})\\s+([\\d,]+\\.\\d{2})$"</span>
+  <span class="highlight">format:</span> <span class="string">"{date:%m/%d/%Y},{description},{-amount},{_}"</span>
+  <span class="highlight">has_header:</span> false</code></pre>
+        <p>Regex delimiters use capture groups <code>()</code> to extract columns. Each group becomes a column matched by the format string.</p>
+
+        <h2 id="format-strings">Format Strings</h2>
+        <p>Format strings describe how to parse each CSV column. They map your CSV structure to the fields Tally needs.</p>
+
+        <h3>Basic Tokens</h3>
+        <table>
+            <tr>
+                <th>Token</th>
+                <th>Description</th>
+            </tr>
+            <tr>
+                <td><code>{date:%m/%d/%Y}</code></td>
+                <td>Date with format specifier</td>
+            </tr>
+            <tr>
+                <td><code>{description}</code></td>
+                <td>Transaction description</td>
+            </tr>
+            <tr>
+                <td><code>{amount}</code></td>
+                <td>Amount column (keep sign as-is)</td>
+            </tr>
+            <tr>
+                <td><code>{-amount}</code></td>
+                <td>Amount column (negate the value)</td>
+            </tr>
+            <tr>
+                <td><code>{+amount}</code></td>
+                <td>Amount column (take absolute value)</td>
+            </tr>
+            <tr>
+                <td><code>{_}</code></td>
+                <td>Skip this column</td>
+            </tr>
+            <tr>
+                <td><code>{custom_name}</code></td>
+                <td>Capture column as custom field</td>
+            </tr>
+            <tr>
+                <td><code>{location}</code></td>
+                <td>Location code for travel detection</td>
+            </tr>
+        </table>
+
+        <h3>Amount Signs</h3>
+        <p>Different banks format amounts differently. Use the right token:</p>
+        <pre><code><span class="comment"># Charges are positive, payments are negative (most credit cards)</span>
+<span class="highlight">format:</span> <span class="string">"{date},{description},{amount}"</span>
+
+<span class="comment"># Charges are negative, deposits are positive (most bank accounts)</span>
+<span class="comment"># Use {-amount} to flip the sign so spending is positive</span>
+<span class="highlight">format:</span> <span class="string">"{date},{description},{-amount}"</span>
+
+<span class="comment"># All amounts are positive, separate debit/credit columns</span>
+<span class="comment"># Use {+amount} to ensure positive, skip the other column</span>
+<span class="highlight">format:</span> <span class="string">"{date},{description},{+amount},{_}"</span></code></pre>
+
+        <h3>Capturing Custom Fields</h3>
+        <p>Any token besides the reserved ones becomes a custom field you can use in rules:</p>
+        <pre><code><span class="comment"># CSV: Date, Type, Memo, Vendor, Amount</span>
+<span class="highlight">format:</span> <span class="string">"{date:%m/%d/%Y},{txn_type},{memo},{vendor},{amount}"</span>
+
+<span class="comment"># Now use in merchants.rules:</span>
+<span class="comment"># match: field.txn_type == "WIRE"</span>
+<span class="comment"># match: contains(field.memo, "Invoice")</span></code></pre>
+
+        <h3>Combining Columns into Description</h3>
+        <p>Some CSVs split transaction info across multiple columns. Use <code>columns.description</code> to combine them:</p>
+        <pre><code><span class="comment"># CSV: Date, Category, Payee, Reference, Amount</span>
+<span class="highlight">- name:</span> My Bank
+  <span class="highlight">file:</span> data/bank.csv
+  <span class="highlight">format:</span> <span class="string">"{date:%m/%d/%Y},{category},{payee},{ref},{amount}"</span>
+  <span class="highlight">columns:</span>
+    <span class="highlight">description:</span> <span class="string">"{payee} - {category}"</span>
+<span class="comment"># Result: "AMAZON - Shopping" instead of just one column</span></code></pre>
+
+        <p>The template can reference any captured field:</p>
+        <pre><code><span class="comment"># Include reference number for matching</span>
+<span class="highlight">columns:</span>
+  <span class="highlight">description:</span> <span class="string">"{payee} ({ref})"</span>
+<span class="comment"># Result: "AMAZON (INV-12345)"</span></code></pre>
+
+        <h3>Examples</h3>
+        <pre><code><span class="comment"># Simple: date, description, amount</span>
+<span class="highlight">format:</span> <span class="string">"{date:%m/%d/%Y},{description},{amount}"</span>
+
+<span class="comment"># Skip columns you don't need</span>
+<span class="highlight">format:</span> <span class="string">"{date:%m/%d/%Y},{_},{description},{_},{amount}"</span>
+
+<span class="comment"># Bank account with negated amounts</span>
+<span class="highlight">format:</span> <span class="string">"{date:%m/%d/%Y},{description},{-amount}"</span>
+
+<span class="comment"># European bank with custom description</span>
+<span class="highlight">- name:</span> German Bank
+  <span class="highlight">file:</span> data/german.csv
+  <span class="highlight">format:</span> <span class="string">"{date:%d.%m.%Y},{_},{txn_type},{vendor},{_},{amount}"</span>
+  <span class="highlight">decimal_separator:</span> <span class="string">","</span>
+  <span class="highlight">columns:</span>
+    <span class="highlight">description:</span> <span class="string">"{vendor} ({txn_type})"</span></code></pre>
+
+        <h2 id="date-formats">Date Formats</h2>
+        <p>Common date format specifiers:</p>
+
+        <table>
+            <tr>
+                <th>Format</th>
+                <th>Example</th>
+                <th>Notes</th>
+            </tr>
+            <tr>
+                <td><code>%m/%d/%Y</code></td>
+                <td>01/15/2025</td>
+                <td>US format</td>
+            </tr>
+            <tr>
+                <td><code>%d/%m/%Y</code></td>
+                <td>15/01/2025</td>
+                <td>European format</td>
+            </tr>
+            <tr>
+                <td><code>%Y-%m-%d</code></td>
+                <td>2025-01-15</td>
+                <td>ISO format</td>
+            </tr>
+            <tr>
+                <td><code>%d.%m.%Y</code></td>
+                <td>15.01.2025</td>
+                <td>German format</td>
+            </tr>
+            <tr>
+                <td><code>%m-%d-%Y</code></td>
+                <td>01-15-2025</td>
+                <td>US with dashes</td>
+            </tr>
+        </table>
+
+        <h2 id="currency">Currency Format</h2>
+        <p>Display amounts in your local currency:</p>
+
+        <pre><code><span class="comment"># US Dollars (default)</span>
+<span class="highlight">currency_format:</span> <span class="string">"${amount}"</span>      <span class="comment"># → $1,234.56</span>
+
+<span class="comment"># Euro</span>
+<span class="highlight">currency_format:</span> <span class="string">"€{amount}"</span>      <span class="comment"># → €1,234.56</span>
+
+<span class="comment"># British Pound</span>
+<span class="highlight">currency_format:</span> <span class="string">"£{amount}"</span>      <span class="comment"># → £1,234.56</span>
+
+<span class="comment"># Polish Zloty (suffix)</span>
+<span class="highlight">currency_format:</span> <span class="string">"{amount} zł"</span>   <span class="comment"># → 1,234.56 zł</span>
+
+<span class="comment"># Japanese Yen (no decimals)</span>
+<span class="highlight">currency_format:</span> <span class="string">"¥{amount}"</span>      <span class="comment"># → ¥1,234</span></code></pre>
+
+        <h3>European Number Format</h3>
+        <p>For CSVs using comma as decimal separator:</p>
+        <pre><code><span class="highlight">- name:</span> German Bank
+  <span class="highlight">file:</span> data/german.csv
+  <span class="highlight">format:</span> <span class="string">"{date:%d.%m.%Y},{description},{amount}"</span>
+  <span class="highlight">decimal_separator:</span> <span class="string">","</span>  <span class="comment"># Parses 1.234,56 correctly</span></code></pre>
+
+        <h2 id="travel">Travel Detection</h2>
+        <p>Tally can automatically detect travel-related transactions using location data from your CSVs.</p>
+
+        <h3>Capturing Location</h3>
+        <p>If your bank includes a state/country code in the CSV, capture it with <code>{location}</code>:</p>
+        <pre><code><span class="comment"># CSV: Date, Description, Amount, State</span>
+<span class="highlight">format:</span> <span class="string">"{date:%m/%d/%Y},{description},{amount},{location}"</span></code></pre>
+
+        <h3>Defining Home Locations</h3>
+        <p>Transactions outside these locations are classified as travel:</p>
+        <pre><code><span class="highlight">home_locations:</span>
+  - WA
+  - OR
+  - CA</code></pre>
+
+        <h3>Custom Travel Labels</h3>
+        <p>Map location codes to readable names in reports:</p>
+        <pre><code><span class="highlight">travel_labels:</span>
+  <span class="highlight">NY:</span> New York Trip
+  <span class="highlight">TX:</span> Austin Conference
+  <span class="highlight">GB:</span> London Vacation</code></pre>
+
+        <h2 id="commands">CLI Commands</h2>
+        <table>
+            <tr>
+                <th>Command</th>
+                <th>Description</th>
+            </tr>
+            <tr>
+                <td><code>tally init [dir]</code></td>
+                <td>Create a new budget folder</td>
+            </tr>
+            <tr>
+                <td><code>tally workflow</code></td>
+                <td>Show next steps (context-aware)</td>
+            </tr>
+            <tr>
+                <td><code>tally run</code></td>
+                <td>Generate HTML spending report</td>
+            </tr>
+            <tr>
+                <td><code>tally inspect &lt;csv&gt;</code></td>
+                <td>Analyze CSV structure</td>
+            </tr>
+            <tr>
+                <td><code>tally discover</code></td>
+                <td>Find uncategorized transactions</td>
+            </tr>
+            <tr>
+                <td><code>tally explain &lt;merchant&gt;</code></td>
+                <td>Explain merchant classification</td>
+            </tr>
+            <tr>
+                <td><code>tally diag</code></td>
+                <td>Debug configuration issues</td>
+            </tr>
+            <tr>
+                <td><code>tally reference</code></td>
+                <td>Show full reference docs</td>
+            </tr>
+        </table>
+
+        <h3>Output Formats</h3>
+        <pre><code><span class="comment"># Different output formats</span>
+tally run                      <span class="comment"># HTML report (default)</span>
+tally run --format json        <span class="comment"># JSON with reasoning</span>
+tally run --format markdown    <span class="comment"># Markdown report</span>
+tally run --format summary     <span class="comment"># Text summary only</span>
+
+<span class="comment"># Verbosity levels</span>
+tally run -v                   <span class="comment"># Include decision trace</span>
+tally run -vv                  <span class="comment"># Include thresholds, CV values</span></code></pre>
+
+        <h3>Filtering</h3>
+        <pre><code><span class="comment"># Filter by classification</span>
+tally run --format json --only monthly,variable
+
+<span class="comment"># Filter by category</span>
+tally run --format json --category Food
+
+<span class="comment"># Explain specific classifications</span>
+tally explain --classification monthly
+tally explain --category Subscriptions
+tally explain --tags business</code></pre>
+    </div>
+</body>
+</html>

--- a/docs/guide.html
+++ b/docs/guide.html
@@ -1,0 +1,420 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Guide - Tally</title>
+    <meta name="description" content="Learn how to use Tally with AI assistants like Claude Code, GitHub Copilot, and Codex to automatically categorize your transactions.">
+    <link rel="icon" type="image/svg+xml" href="logo.svg">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=JetBrains+Mono&display=swap" rel="stylesheet">
+    <style>
+        * { box-sizing: border-box; margin: 0; padding: 0; }
+
+        body {
+            font-family: 'Inter', -apple-system, sans-serif;
+            background: linear-gradient(135deg, #0a1f0a 0%, #0d2818 50%, #061a12 100%);
+            color: #fff;
+            min-height: 100vh;
+            line-height: 1.6;
+        }
+
+        nav {
+            background: rgba(0,0,0,0.3);
+            border-bottom: 1px solid rgba(255,255,255,0.08);
+            padding: 1rem 2rem;
+            position: sticky;
+            top: 0;
+            z-index: 100;
+            backdrop-filter: blur(10px);
+        }
+
+        nav .nav-inner {
+            max-width: 1100px;
+            margin: 0 auto;
+            display: flex;
+            align-items: center;
+            gap: 2rem;
+        }
+
+        nav .nav-logo {
+            font-family: 'JetBrains Mono', monospace;
+            font-size: 1.25rem;
+            font-weight: 600;
+            color: #4ade80;
+            text-decoration: none;
+            display: flex;
+            align-items: center;
+            gap: 0.5rem;
+        }
+
+        nav .nav-logo img {
+            width: 1.5rem;
+            height: 1.5rem;
+        }
+
+        nav .nav-links {
+            display: flex;
+            gap: 1.5rem;
+            flex: 1;
+        }
+
+        nav .nav-links a {
+            color: rgba(255,255,255,0.6);
+            text-decoration: none;
+            font-size: 0.9rem;
+            transition: color 0.2s;
+        }
+
+        nav .nav-links a:hover,
+        nav .nav-links a.active {
+            color: #4ade80;
+        }
+
+        nav .nav-github {
+            color: rgba(255,255,255,0.6);
+            text-decoration: none;
+            font-size: 0.9rem;
+            transition: color 0.2s;
+        }
+
+        nav .nav-github:hover {
+            color: #4ade80;
+        }
+
+        .container {
+            max-width: 800px;
+            margin: 0 auto;
+            padding: 3rem 2rem 5rem;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            font-weight: 600;
+            margin-bottom: 0.5rem;
+            background: linear-gradient(135deg, #4ade80 0%, #22c55e 50%, #16a34a 100%);
+            -webkit-background-clip: text;
+            -webkit-text-fill-color: transparent;
+            background-clip: text;
+        }
+
+        .subtitle {
+            color: rgba(255,255,255,0.6);
+            font-size: 1.1rem;
+            margin-bottom: 3rem;
+        }
+
+        h2 {
+            font-size: 1.25rem;
+            font-weight: 600;
+            color: #fff;
+            margin: 2.5rem 0 1rem;
+            padding-top: 1rem;
+        }
+
+        h2:first-of-type {
+            margin-top: 0;
+        }
+
+        h3 {
+            font-size: 1rem;
+            font-weight: 600;
+            color: rgba(255,255,255,0.9);
+            margin: 1.5rem 0 0.75rem;
+        }
+
+        p {
+            color: rgba(255,255,255,0.8);
+            margin-bottom: 1rem;
+        }
+
+        pre {
+            background: #0d0d0d;
+            border: 1px solid rgba(255,255,255,0.1);
+            border-radius: 8px;
+            padding: 1rem 1.25rem;
+            overflow-x: auto;
+            margin: 1rem 0 1.5rem;
+        }
+
+        code {
+            font-family: 'JetBrains Mono', monospace;
+            font-size: 0.85rem;
+        }
+
+        pre code {
+            color: #e0e0e0;
+        }
+
+        p code {
+            background: rgba(255,255,255,0.1);
+            padding: 0.15rem 0.4rem;
+            border-radius: 4px;
+            font-size: 0.85rem;
+        }
+
+        .cmd::before {
+            content: '$ ';
+            color: #4ade80;
+        }
+
+        .comment {
+            color: rgba(255,255,255,0.4);
+        }
+
+        .highlight {
+            color: #4ade80;
+        }
+
+        .output {
+            color: rgba(255,255,255,0.6);
+        }
+
+        ul, ol {
+            margin: 1rem 0 1.5rem 1.5rem;
+            color: rgba(255,255,255,0.8);
+        }
+
+        li {
+            margin-bottom: 0.5rem;
+        }
+
+        a {
+            color: #4ade80;
+            text-decoration: none;
+        }
+
+        a:hover {
+            text-decoration: underline;
+        }
+
+        .callout {
+            background: rgba(74, 222, 128, 0.05);
+            border: 1px solid rgba(74, 222, 128, 0.15);
+            border-radius: 12px;
+            padding: 1.25rem 1.5rem;
+            margin: 1.5rem 0;
+        }
+
+        .callout-title {
+            color: #4ade80;
+            font-weight: 600;
+            font-size: 0.9rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .callout p {
+            margin-bottom: 0;
+            font-size: 0.95rem;
+        }
+
+        .user-msg {
+            background: rgba(74, 222, 128, 0.1);
+            border-left: 3px solid #4ade80;
+            padding: 0.75rem 1rem;
+            margin: 1rem 0;
+            font-style: italic;
+            color: rgba(255,255,255,0.9);
+        }
+
+        .agent-list {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+            gap: 1rem;
+            margin: 1rem 0 1.5rem;
+        }
+
+        .agent-item {
+            background: rgba(255,255,255,0.03);
+            border: 1px solid rgba(255,255,255,0.08);
+            border-radius: 8px;
+            padding: 1rem;
+        }
+
+        .agent-item strong {
+            color: #fff;
+            display: block;
+            margin-bottom: 0.25rem;
+        }
+
+        .agent-item span {
+            color: rgba(255,255,255,0.5);
+            font-size: 0.85rem;
+        }
+
+        @media (max-width: 768px) {
+            nav .nav-inner {
+                flex-wrap: wrap;
+                gap: 1rem;
+            }
+            nav .nav-links {
+                order: 3;
+                width: 100%;
+                flex-wrap: wrap;
+                gap: 1rem;
+            }
+            h1 { font-size: 2rem; }
+            .container { padding: 2rem 1.5rem 3rem; }
+        }
+    </style>
+</head>
+<body>
+    <nav>
+        <div class="nav-inner">
+            <a href="index.html" class="nav-logo"><img src="logo.svg" alt="Tally">tally</a>
+            <div class="nav-links">
+                <a href="quickstart.html">Quick Start</a>
+                <a href="guide.html" class="active">Guide</a>
+                <a href="reference.html">Reference</a>
+                <a href="formats.html">Formats</a>
+            </div>
+            <a href="https://github.com/davidfowl/tally" class="nav-github">GitHub</a>
+        </div>
+    </nav>
+
+    <div class="container">
+        <h1>Guide</h1>
+        <p class="subtitle">Using Tally with AI assistants</p>
+
+        <h2>How It Works</h2>
+        <p>Tally is a <strong>rule engine</strong> that classifies transactions. The AI assistant is the <strong>operator</strong> that writes the rules. Together they create a feedback loop:</p>
+        <ol>
+            <li>Tally finds uncategorized transactions</li>
+            <li>AI identifies the merchants and writes categorization rules</li>
+            <li>Tally applies rules and finds remaining unknowns</li>
+            <li>Repeat until everything is categorized</li>
+        </ol>
+
+        <h2>Supported AI Assistants</h2>
+        <div class="agent-list">
+            <div class="agent-item">
+                <strong>Claude Code</strong>
+                <span>Anthropic CLI</span>
+            </div>
+            <div class="agent-item">
+                <strong>GitHub Copilot</strong>
+                <span>VS Code / CLI</span>
+            </div>
+            <div class="agent-item">
+                <strong>Codex</strong>
+                <span>OpenAI CLI</span>
+            </div>
+            <div class="agent-item">
+                <strong>Cursor</strong>
+                <span>AI IDE</span>
+            </div>
+        </div>
+        <p>Any AI agent that can run command-line tools will work with Tally.</p>
+
+        <h2>Starting a Session</h2>
+        <p>After <a href="quickstart.html">setting up your budget folder</a>, open it in your AI assistant and tell it what to do:</p>
+
+        <div class="user-msg">"Use tally to configure my Chase credit card CSV"</div>
+        <div class="user-msg">"Use tally to categorize all my transactions"</div>
+        <div class="user-msg">"Use tally to generate my spending report"</div>
+
+        <p>The agent will run <code>tally workflow</code> to understand the current state and follow the instructions.</p>
+
+        <h2>The Workflow Command</h2>
+        <p>The <code>tally workflow</code> command is context-aware. It detects your setup state and shows relevant next steps:</p>
+
+        <h3>No data sources configured</h3>
+        <pre><code><span class="cmd">tally workflow</span>
+<span class="output">
+No data sources configured yet.
+
+To add a data source:
+1. Run: tally inspect data/yourfile.csv
+2. Add the suggested config to settings.yaml
+</span></code></pre>
+
+        <h3>Unknown merchants found</h3>
+        <pre><code><span class="cmd">tally workflow</span>
+<span class="output">
+Found 47 unknown merchants.
+
+Run: tally discover --format json
+Then add rules to config/merchants.rules
+</span></code></pre>
+
+        <h3>Ready to generate report</h3>
+        <pre><code><span class="cmd">tally workflow</span>
+<span class="output">
+All transactions categorized!
+
+Run: tally run
+</span></code></pre>
+
+        <h2>Key Commands for AI Agents</h2>
+
+        <h3>Discover unknown merchants</h3>
+        <pre><code><span class="cmd">tally discover --format json</span></code></pre>
+        <p>Returns uncategorized transactions with suggested patterns. The AI uses this to write rules.</p>
+
+        <h3>Inspect CSV structure</h3>
+        <pre><code><span class="cmd">tally inspect data/chase.csv</span></code></pre>
+        <p>Shows column headers and sample data. Suggests format string and account type.</p>
+
+        <h3>Explain a classification</h3>
+        <pre><code><span class="cmd">tally explain Netflix -vv</span></code></pre>
+        <p>Shows why a merchant is classified a certain way, including which rule matched.</p>
+
+        <h3>Debug configuration</h3>
+        <pre><code><span class="cmd">tally diag --format json</span></code></pre>
+        <p>Validates configuration and shows any errors.</p>
+
+        <h3>Run full analysis</h3>
+        <pre><code><span class="cmd">tally run --format json -v</span></code></pre>
+        <p>Returns complete analysis with classification reasoning.</p>
+
+        <h2>Writing Rules</h2>
+        <p>When the AI finds unknown transactions, it adds rules to <code>config/merchants.rules</code>:</p>
+        <pre><code><span class="highlight">[Netflix]</span>
+match: contains("NETFLIX")
+category: Subscriptions
+subcategory: Streaming
+tags: entertainment, recurring
+
+<span class="highlight">[Whole Foods]</span>
+match: contains("WHOLEFDS") or contains("WHOLE FOODS")
+category: Food
+subcategory: Grocery</code></pre>
+
+        <p>See the <a href="reference.html">Reference</a> for full syntax.</p>
+
+        <div class="callout">
+            <div class="callout-title">Tip: Be specific with the AI</div>
+            <p>Tell the AI your preferences: "Coffee shops should be Food > Coffee, not Food > Restaurant" or "Tag all Uber rides as business, reimbursable".</p>
+        </div>
+
+        <h2>Customizing Categories</h2>
+        <p>Tally doesn't have predefined categories. You define them in your rules:</p>
+        <ul>
+            <li><strong>Category</strong> - Primary grouping (Food, Transportation, Bills)</li>
+            <li><strong>Subcategory</strong> - Secondary grouping (Grocery, Rideshare, Utilities)</li>
+            <li><strong>Tags</strong> - Labels for filtering (business, reimbursable, recurring)</li>
+        </ul>
+        <p>Tell the AI your preferred structure and it will use it consistently.</p>
+
+        <h2>Generating Reports</h2>
+        <p>Once transactions are categorized:</p>
+        <pre><code><span class="cmd">tally run</span></code></pre>
+        <p>This generates an HTML report with:</p>
+        <ul>
+            <li>Monthly spending breakdown</li>
+            <li>Recurring expense detection</li>
+            <li>Category summaries</li>
+            <li>Transaction search and filtering</li>
+        </ul>
+
+        <h2>Iterating</h2>
+        <p>As you review the report, you might want changes:</p>
+        <div class="user-msg">"Move Starbucks from Restaurant to Coffee"</div>
+        <div class="user-msg">"Split Amazon purchases - anything over $100 should be Shopping > Electronics"</div>
+        <div class="user-msg">"Tag all transactions in December as holiday"</div>
+
+        <p>The AI updates the rules, and you can regenerate the report.</p>
+    </div>
+</body>
+</html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -78,6 +78,68 @@
             line-height: 1.6;
         }
 
+        nav {
+            background: rgba(0,0,0,0.3);
+            border-bottom: 1px solid rgba(255,255,255,0.08);
+            padding: 1rem 2rem;
+            position: sticky;
+            top: 0;
+            z-index: 100;
+            backdrop-filter: blur(10px);
+        }
+
+        nav .nav-inner {
+            max-width: 1100px;
+            margin: 0 auto;
+            display: flex;
+            align-items: center;
+            gap: 2rem;
+        }
+
+        nav .nav-logo {
+            font-family: 'JetBrains Mono', monospace;
+            font-size: 1.25rem;
+            font-weight: 600;
+            color: #4ade80;
+            text-decoration: none;
+            display: flex;
+            align-items: center;
+            gap: 0.5rem;
+        }
+
+        nav .nav-logo img {
+            width: 1.5rem;
+            height: 1.5rem;
+        }
+
+        nav .nav-links {
+            display: flex;
+            gap: 1.5rem;
+            flex: 1;
+        }
+
+        nav .nav-links a {
+            color: rgba(255,255,255,0.6);
+            text-decoration: none;
+            font-size: 0.9rem;
+            transition: color 0.2s;
+        }
+
+        nav .nav-links a:hover {
+            color: #4ade80;
+        }
+
+        nav .nav-github {
+            color: rgba(255,255,255,0.6);
+            text-decoration: none;
+            font-size: 0.9rem;
+            transition: color 0.2s;
+        }
+
+        nav .nav-github:hover {
+            color: #4ade80;
+        }
+
         .container {
             max-width: 1100px;
             margin: 0 auto;
@@ -463,6 +525,16 @@
         }
 
         @media (max-width: 768px) {
+            nav .nav-inner {
+                flex-wrap: wrap;
+                gap: 1rem;
+            }
+            nav .nav-links {
+                order: 3;
+                width: 100%;
+                flex-wrap: wrap;
+                gap: 1rem;
+            }
             .container { padding: 3rem 1.5rem; }
             .logo { font-size: 2.5rem; }
             .logo-icon { width: 2rem; height: 2rem; }
@@ -489,6 +561,19 @@
     </style>
 </head>
 <body>
+    <nav>
+        <div class="nav-inner">
+            <a href="index.html" class="nav-logo"><img src="logo.svg" alt="Tally">tally</a>
+            <div class="nav-links">
+                <a href="quickstart.html">Quick Start</a>
+                <a href="guide.html">Guide</a>
+                <a href="reference.html">Reference</a>
+                <a href="formats.html">Formats</a>
+            </div>
+            <a href="https://github.com/davidfowl/tally" class="nav-github">GitHub</a>
+        </div>
+    </nav>
+
     <div class="container">
         <header class="hero">
             <h1 class="logo"><img src="logo.svg" alt="Tally logo" class="logo-icon">tally</h1>
@@ -550,16 +635,6 @@
                 </div>
             </div>
 
-            <div class="install-card">
-                <div class="install-header">
-                    <div class="install-dots"><span></span><span></span><span></span></div>
-                    <div class="install-label">Python (uv)</div>
-                </div>
-                <div class="install-body">
-                    <div class="install-code" data-cmd="uv tool install git+https://github.com/davidfowl/tally">uv tool install git+https://github.com/davidfowl/tally</div>
-                    <button class="copy-btn" onclick="copyCmd(this)">Copy</button>
-                </div>
-            </div>
         </section>
 
         <section class="workflow">
@@ -620,7 +695,7 @@
         <footer class="links">
             <a href="https://github.com/davidfowl/tally">GitHub</a>
             <a href="https://github.com/davidfowl/tally/releases">Releases</a>
-            <a href="https://github.com/davidfowl/tally#readme">Docs</a>
+            <a href="quickstart.html">Docs</a>
         </footer>
     </div>
 

--- a/docs/quickstart.html
+++ b/docs/quickstart.html
@@ -1,0 +1,301 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Quick Start - Tally</title>
+    <meta name="description" content="Get started with Tally in 5 minutes. Install, configure, and generate your first spending report.">
+    <link rel="icon" type="image/svg+xml" href="logo.svg">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=JetBrains+Mono&display=swap" rel="stylesheet">
+    <style>
+        * { box-sizing: border-box; margin: 0; padding: 0; }
+
+        body {
+            font-family: 'Inter', -apple-system, sans-serif;
+            background: linear-gradient(135deg, #0a1f0a 0%, #0d2818 50%, #061a12 100%);
+            color: #fff;
+            min-height: 100vh;
+            line-height: 1.6;
+        }
+
+        nav {
+            background: rgba(0,0,0,0.3);
+            border-bottom: 1px solid rgba(255,255,255,0.08);
+            padding: 1rem 2rem;
+            position: sticky;
+            top: 0;
+            z-index: 100;
+            backdrop-filter: blur(10px);
+        }
+
+        nav .nav-inner {
+            max-width: 1100px;
+            margin: 0 auto;
+            display: flex;
+            align-items: center;
+            gap: 2rem;
+        }
+
+        nav .nav-logo {
+            font-family: 'JetBrains Mono', monospace;
+            font-size: 1.25rem;
+            font-weight: 600;
+            color: #4ade80;
+            text-decoration: none;
+            display: flex;
+            align-items: center;
+            gap: 0.5rem;
+        }
+
+        nav .nav-logo img {
+            width: 1.5rem;
+            height: 1.5rem;
+        }
+
+        nav .nav-links {
+            display: flex;
+            gap: 1.5rem;
+            flex: 1;
+        }
+
+        nav .nav-links a {
+            color: rgba(255,255,255,0.6);
+            text-decoration: none;
+            font-size: 0.9rem;
+            transition: color 0.2s;
+        }
+
+        nav .nav-links a:hover,
+        nav .nav-links a.active {
+            color: #4ade80;
+        }
+
+        nav .nav-github {
+            color: rgba(255,255,255,0.6);
+            text-decoration: none;
+            font-size: 0.9rem;
+            transition: color 0.2s;
+        }
+
+        nav .nav-github:hover {
+            color: #4ade80;
+        }
+
+        .container {
+            max-width: 800px;
+            margin: 0 auto;
+            padding: 3rem 2rem 5rem;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            font-weight: 600;
+            margin-bottom: 0.5rem;
+            background: linear-gradient(135deg, #4ade80 0%, #22c55e 50%, #16a34a 100%);
+            -webkit-background-clip: text;
+            -webkit-text-fill-color: transparent;
+            background-clip: text;
+        }
+
+        .subtitle {
+            color: rgba(255,255,255,0.6);
+            font-size: 1.1rem;
+            margin-bottom: 3rem;
+        }
+
+        h2 {
+            font-size: 1.25rem;
+            font-weight: 600;
+            color: #fff;
+            margin: 2.5rem 0 1rem;
+            padding-top: 1rem;
+        }
+
+        h2:first-of-type {
+            margin-top: 0;
+        }
+
+        p {
+            color: rgba(255,255,255,0.8);
+            margin-bottom: 1rem;
+        }
+
+        .step-number {
+            display: inline-block;
+            background: rgba(74, 222, 128, 0.15);
+            color: #4ade80;
+            font-weight: 600;
+            width: 1.75rem;
+            height: 1.75rem;
+            border-radius: 50%;
+            text-align: center;
+            line-height: 1.75rem;
+            font-size: 0.9rem;
+            margin-right: 0.5rem;
+        }
+
+        pre {
+            background: #0d0d0d;
+            border: 1px solid rgba(255,255,255,0.1);
+            border-radius: 8px;
+            padding: 1rem 1.25rem;
+            overflow-x: auto;
+            margin: 1rem 0 1.5rem;
+        }
+
+        code {
+            font-family: 'JetBrains Mono', monospace;
+            font-size: 0.85rem;
+        }
+
+        pre code {
+            color: #e0e0e0;
+        }
+
+        .cmd::before {
+            content: '$ ';
+            color: #4ade80;
+        }
+
+        .comment {
+            color: rgba(255,255,255,0.4);
+        }
+
+        .highlight {
+            color: #4ade80;
+        }
+
+        ul, ol {
+            margin: 1rem 0 1.5rem 1.5rem;
+            color: rgba(255,255,255,0.8);
+        }
+
+        li {
+            margin-bottom: 0.5rem;
+        }
+
+        a {
+            color: #4ade80;
+            text-decoration: none;
+        }
+
+        a:hover {
+            text-decoration: underline;
+        }
+
+        .next-steps {
+            background: rgba(74, 222, 128, 0.05);
+            border: 1px solid rgba(74, 222, 128, 0.15);
+            border-radius: 12px;
+            padding: 1.5rem;
+            margin-top: 3rem;
+        }
+
+        .next-steps h3 {
+            color: #4ade80;
+            font-size: 1rem;
+            margin-bottom: 1rem;
+        }
+
+        .next-steps a {
+            display: block;
+            padding: 0.5rem 0;
+            color: rgba(255,255,255,0.8);
+        }
+
+        .next-steps a:hover {
+            color: #4ade80;
+        }
+
+        @media (max-width: 768px) {
+            nav .nav-inner {
+                flex-wrap: wrap;
+                gap: 1rem;
+            }
+            nav .nav-links {
+                order: 3;
+                width: 100%;
+                flex-wrap: wrap;
+                gap: 1rem;
+            }
+            h1 { font-size: 2rem; }
+            .container { padding: 2rem 1.5rem 3rem; }
+        }
+    </style>
+</head>
+<body>
+    <nav>
+        <div class="nav-inner">
+            <a href="index.html" class="nav-logo"><img src="logo.svg" alt="Tally">tally</a>
+            <div class="nav-links">
+                <a href="quickstart.html" class="active">Quick Start</a>
+                <a href="guide.html">Guide</a>
+                <a href="reference.html">Reference</a>
+                <a href="formats.html">Formats</a>
+            </div>
+            <a href="https://github.com/davidfowl/tally" class="nav-github">GitHub</a>
+        </div>
+    </nav>
+
+    <div class="container">
+        <h1>Quick Start</h1>
+        <p class="subtitle">Get Tally running in 5 minutes</p>
+
+        <h2><span class="step-number">1</span> Install Tally</h2>
+        <p>Choose your platform:</p>
+        <pre><code><span class="comment"># Linux / macOS</span>
+<span class="cmd">curl -fsSL https://tallyai.money/install.sh | bash</span>
+
+<span class="comment"># Windows PowerShell</span>
+<span class="cmd">irm https://tallyai.money/install.ps1 | iex</span></code></pre>
+
+        <h2><span class="step-number">2</span> Create a Budget Folder</h2>
+        <p>Initialize a new folder to hold your configuration and data:</p>
+        <pre><code><span class="cmd">tally init ./my-budget</span>
+<span class="cmd">cd my-budget</span></code></pre>
+        <p>This creates:</p>
+        <ul>
+            <li><code>settings.yaml</code> - Configuration file</li>
+            <li><code>config/merchants.rules</code> - Transaction categorization rules</li>
+            <li><code>data/</code> - Folder for your CSV files</li>
+            <li><code>AGENTS.md</code> - Instructions for AI assistants</li>
+        </ul>
+
+        <h2><span class="step-number">3</span> Add Your Bank CSVs</h2>
+        <p>Download transaction exports from your bank and credit cards, then copy them to the <code>data/</code> folder.</p>
+
+        <h2><span class="step-number">4</span> Configure Data Sources</h2>
+        <p>Edit <code>settings.yaml</code> to point to your CSV files:</p>
+        <pre><code><span class="highlight">year:</span> 2025
+
+<span class="highlight">data_sources:</span>
+  - <span class="highlight">name:</span> Chase
+    <span class="highlight">file:</span> data/chase.csv
+    <span class="highlight">format:</span> "{date:%m/%d/%Y},{description},{amount}"
+
+  - <span class="highlight">name:</span> Bank of America
+    <span class="highlight">file:</span> data/bofa.csv
+    <span class="highlight">format:</span> "{date:%m/%d/%Y},{description},{amount}"</code></pre>
+        <p>Use <code>tally inspect data/yourfile.csv</code> to see the CSV structure and get format suggestions.</p>
+
+        <h2><span class="step-number">5</span> Run the Workflow</h2>
+        <p>Check what to do next:</p>
+        <pre><code><span class="cmd">tally workflow</span></code></pre>
+        <p>This command detects your setup state and shows context-aware instructions. If you have an AI assistant (Claude Code, Copilot, Cursor), it will guide it through categorizing your transactions.</p>
+
+        <h2><span class="step-number">6</span> Generate Your Report</h2>
+        <p>Once transactions are categorized:</p>
+        <pre><code><span class="cmd">tally run</span></code></pre>
+        <p>This generates an HTML spending report with all your transactions organized by category, recurring expenses identified, and monthly trends visualized.</p>
+
+        <div class="next-steps">
+            <h3>Next Steps</h3>
+            <a href="guide.html">Guide &rarr; Learn how to use Tally with an AI assistant</a>
+            <a href="formats.html">Formats &rarr; Understand settings.yaml and format strings</a>
+            <a href="reference.html">Reference &rarr; Full merchants.rules and views.rules syntax</a>
+        </div>
+    </div>
+</body>
+</html>

--- a/docs/reference.html
+++ b/docs/reference.html
@@ -1,0 +1,763 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Reference - Tally</title>
+    <meta name="description" content="Complete reference for Tally's merchants.rules and views.rules syntax. Match functions, conditions, tags, and filter expressions.">
+    <link rel="icon" type="image/svg+xml" href="logo.svg">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=JetBrains+Mono&display=swap" rel="stylesheet">
+    <style>
+        * { box-sizing: border-box; margin: 0; padding: 0; }
+
+        body {
+            font-family: 'Inter', -apple-system, sans-serif;
+            background: linear-gradient(135deg, #0a1f0a 0%, #0d2818 50%, #061a12 100%);
+            color: #fff;
+            min-height: 100vh;
+            line-height: 1.6;
+        }
+
+        nav {
+            background: rgba(0,0,0,0.3);
+            border-bottom: 1px solid rgba(255,255,255,0.08);
+            padding: 1rem 2rem;
+            position: sticky;
+            top: 0;
+            z-index: 100;
+            backdrop-filter: blur(10px);
+        }
+
+        nav .nav-inner {
+            max-width: 1100px;
+            margin: 0 auto;
+            display: flex;
+            align-items: center;
+            gap: 2rem;
+        }
+
+        nav .nav-logo {
+            font-family: 'JetBrains Mono', monospace;
+            font-size: 1.25rem;
+            font-weight: 600;
+            color: #4ade80;
+            text-decoration: none;
+            display: flex;
+            align-items: center;
+            gap: 0.5rem;
+        }
+
+        nav .nav-logo img {
+            width: 1.5rem;
+            height: 1.5rem;
+        }
+
+        nav .nav-links {
+            display: flex;
+            gap: 1.5rem;
+            flex: 1;
+        }
+
+        nav .nav-links a {
+            color: rgba(255,255,255,0.6);
+            text-decoration: none;
+            font-size: 0.9rem;
+            transition: color 0.2s;
+        }
+
+        nav .nav-links a:hover,
+        nav .nav-links a.active {
+            color: #4ade80;
+        }
+
+        nav .nav-github {
+            color: rgba(255,255,255,0.6);
+            text-decoration: none;
+            font-size: 0.9rem;
+            transition: color 0.2s;
+        }
+
+        nav .nav-github:hover {
+            color: #4ade80;
+        }
+
+        .container {
+            max-width: 900px;
+            margin: 0 auto;
+            padding: 3rem 2rem 5rem;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            font-weight: 600;
+            margin-bottom: 0.5rem;
+            background: linear-gradient(135deg, #4ade80 0%, #22c55e 50%, #16a34a 100%);
+            -webkit-background-clip: text;
+            -webkit-text-fill-color: transparent;
+            background-clip: text;
+        }
+
+        .subtitle {
+            color: rgba(255,255,255,0.6);
+            font-size: 1.1rem;
+            margin-bottom: 2rem;
+        }
+
+        .toc {
+            background: rgba(255,255,255,0.03);
+            border: 1px solid rgba(255,255,255,0.08);
+            border-radius: 12px;
+            padding: 1.5rem;
+            margin-bottom: 3rem;
+        }
+
+        .toc-title {
+            font-size: 0.8rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.1em;
+            color: rgba(255,255,255,0.5);
+            margin-bottom: 1rem;
+        }
+
+        .toc-columns {
+            display: grid;
+            grid-template-columns: 1fr 1fr;
+            gap: 0.5rem 2rem;
+        }
+
+        .toc a {
+            color: rgba(255,255,255,0.7);
+            text-decoration: none;
+            font-size: 0.9rem;
+            display: block;
+            padding: 0.25rem 0;
+        }
+
+        .toc a:hover {
+            color: #4ade80;
+        }
+
+        h2 {
+            font-size: 1.5rem;
+            font-weight: 600;
+            color: #fff;
+            margin: 3rem 0 1rem;
+            padding-top: 1rem;
+            border-top: 1px solid rgba(255,255,255,0.08);
+        }
+
+        h2:first-of-type {
+            margin-top: 0;
+            border-top: none;
+            padding-top: 0;
+        }
+
+        h3 {
+            font-size: 1.1rem;
+            font-weight: 600;
+            color: rgba(255,255,255,0.95);
+            margin: 2rem 0 0.75rem;
+        }
+
+        p {
+            color: rgba(255,255,255,0.8);
+            margin-bottom: 1rem;
+        }
+
+        pre {
+            background: #0d0d0d;
+            border: 1px solid rgba(255,255,255,0.1);
+            border-radius: 8px;
+            padding: 1rem 1.25rem;
+            overflow-x: auto;
+            margin: 1rem 0 1.5rem;
+        }
+
+        code {
+            font-family: 'JetBrains Mono', monospace;
+            font-size: 0.85rem;
+        }
+
+        pre code {
+            color: #e0e0e0;
+        }
+
+        p code {
+            background: rgba(255,255,255,0.1);
+            padding: 0.15rem 0.4rem;
+            border-radius: 4px;
+            font-size: 0.85rem;
+        }
+
+        .comment {
+            color: rgba(255,255,255,0.4);
+        }
+
+        .highlight {
+            color: #4ade80;
+        }
+
+        .keyword {
+            color: #60a5fa;
+        }
+
+        .string {
+            color: #fbbf24;
+        }
+
+        table {
+            width: 100%;
+            border-collapse: collapse;
+            margin: 1rem 0 1.5rem;
+            font-size: 0.9rem;
+        }
+
+        th, td {
+            text-align: left;
+            padding: 0.75rem 1rem;
+            border-bottom: 1px solid rgba(255,255,255,0.08);
+        }
+
+        th {
+            color: rgba(255,255,255,0.5);
+            font-weight: 500;
+            font-size: 0.8rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+        }
+
+        td {
+            color: rgba(255,255,255,0.8);
+        }
+
+        td code {
+            background: rgba(255,255,255,0.08);
+            padding: 0.2rem 0.4rem;
+            border-radius: 4px;
+            font-size: 0.8rem;
+        }
+
+        ul, ol {
+            margin: 1rem 0 1.5rem 1.5rem;
+            color: rgba(255,255,255,0.8);
+        }
+
+        li {
+            margin-bottom: 0.5rem;
+        }
+
+        a {
+            color: #4ade80;
+            text-decoration: none;
+        }
+
+        a:hover {
+            text-decoration: underline;
+        }
+
+        .note {
+            background: rgba(96, 165, 250, 0.1);
+            border: 1px solid rgba(96, 165, 250, 0.2);
+            border-radius: 8px;
+            padding: 1rem 1.25rem;
+            margin: 1rem 0 1.5rem;
+            font-size: 0.9rem;
+        }
+
+        .note-title {
+            color: #60a5fa;
+            font-weight: 600;
+            margin-bottom: 0.5rem;
+        }
+
+        .note p {
+            margin-bottom: 0;
+        }
+
+        @media (max-width: 768px) {
+            nav .nav-inner {
+                flex-wrap: wrap;
+                gap: 1rem;
+            }
+            nav .nav-links {
+                order: 3;
+                width: 100%;
+                flex-wrap: wrap;
+                gap: 1rem;
+            }
+            h1 { font-size: 2rem; }
+            .container { padding: 2rem 1.5rem 3rem; }
+            .toc-columns { grid-template-columns: 1fr; }
+            table { font-size: 0.8rem; }
+            th, td { padding: 0.5rem; }
+        }
+    </style>
+</head>
+<body>
+    <nav>
+        <div class="nav-inner">
+            <a href="index.html" class="nav-logo"><img src="logo.svg" alt="Tally">tally</a>
+            <div class="nav-links">
+                <a href="quickstart.html">Quick Start</a>
+                <a href="guide.html">Guide</a>
+                <a href="reference.html" class="active">Reference</a>
+                <a href="formats.html">Formats</a>
+            </div>
+            <a href="https://github.com/davidfowl/tally" class="nav-github">GitHub</a>
+        </div>
+    </nav>
+
+    <div class="container">
+        <h1>Reference</h1>
+        <p class="subtitle">Complete syntax for merchants.rules and views.rules</p>
+
+        <div class="toc">
+            <div class="toc-title">Contents</div>
+            <div class="toc-columns">
+                <div>
+                    <a href="#merchants-rules">Merchants Rules</a>
+                    <a href="#match-functions">Match Functions</a>
+                    <a href="#conditions">Amount &amp; Date Conditions</a>
+                    <a href="#combining">Combining Conditions</a>
+                    <a href="#custom-fields">Custom CSV Fields</a>
+                    <a href="#extraction">Extraction Functions</a>
+                </div>
+                <div>
+                    <a href="#variables">Variables</a>
+                    <a href="#transforms">Field Transforms</a>
+                    <a href="#special-tags">Special Tags</a>
+                    <a href="#dynamic-tags">Dynamic Tags</a>
+                    <a href="#views-rules">Views Rules</a>
+                    <a href="#view-functions">View Functions</a>
+                </div>
+            </div>
+        </div>
+
+        <h2 id="merchants-rules">Merchants Rules</h2>
+        <p>File: <code>config/merchants.rules</code></p>
+        <p>Categorize transactions by matching descriptions to patterns.</p>
+
+        <h3>Rule Structure</h3>
+        <pre><code><span class="highlight">[Rule Name]</span>              <span class="comment"># Display name for matched transactions</span>
+<span class="keyword">match:</span> &lt;expression&gt;      <span class="comment"># Required: when to apply this rule</span>
+<span class="keyword">category:</span> &lt;Category&gt;     <span class="comment"># Required: primary grouping</span>
+<span class="keyword">subcategory:</span> &lt;Sub&gt;       <span class="comment"># Optional: secondary grouping</span>
+<span class="keyword">tags:</span> tag1, tag2         <span class="comment"># Optional: labels for filtering</span></code></pre>
+
+        <h3>Example</h3>
+        <pre><code><span class="highlight">[Netflix]</span>
+<span class="keyword">match:</span> contains(<span class="string">"NETFLIX"</span>)
+<span class="keyword">category:</span> Subscriptions
+<span class="keyword">subcategory:</span> Streaming
+<span class="keyword">tags:</span> entertainment, recurring
+
+<span class="highlight">[Costco Grocery]</span>
+<span class="keyword">match:</span> contains(<span class="string">"COSTCO"</span>) and amount &lt;= 200
+<span class="keyword">category:</span> Food
+<span class="keyword">subcategory:</span> Grocery
+
+<span class="highlight">[Costco Bulk]</span>
+<span class="keyword">match:</span> contains(<span class="string">"COSTCO"</span>) and amount &gt; 200
+<span class="keyword">category:</span> Shopping
+<span class="keyword">subcategory:</span> Wholesale</code></pre>
+
+        <h2 id="match-functions">Match Functions</h2>
+        <p>All match functions search <code>description</code> by default. Add an optional first argument to search a custom field.</p>
+
+        <table>
+            <tr>
+                <th>Function</th>
+                <th>Description</th>
+            </tr>
+            <tr>
+                <td><code>contains("text")</code></td>
+                <td>Case-insensitive substring match</td>
+            </tr>
+            <tr>
+                <td><code>regex("pattern")</code></td>
+                <td>Perl-compatible regex</td>
+            </tr>
+            <tr>
+                <td><code>normalized("text")</code></td>
+                <td>Ignores spaces, hyphens, punctuation</td>
+            </tr>
+            <tr>
+                <td><code>anyof("a", "b", ...)</code></td>
+                <td>Match any of multiple patterns</td>
+            </tr>
+            <tr>
+                <td><code>startswith("text")</code></td>
+                <td>Match only at beginning</td>
+            </tr>
+            <tr>
+                <td><code>fuzzy("text")</code></td>
+                <td>Approximate matching (80% similar)</td>
+            </tr>
+            <tr>
+                <td><code>fuzzy("text", 0.90)</code></td>
+                <td>Fuzzy with custom threshold</td>
+            </tr>
+        </table>
+
+        <h3>Examples</h3>
+        <pre><code><span class="comment"># Case-insensitive substring</span>
+<span class="keyword">match:</span> contains(<span class="string">"NETFLIX"</span>)
+<span class="comment"># Matches: NETFLIX.COM, netflix, Netflix Inc</span>
+
+<span class="comment"># Regex with negative lookahead</span>
+<span class="keyword">match:</span> regex(<span class="string">"UBER\\s(?!EATS)"</span>)
+<span class="comment"># Matches: UBER TRIP, but not UBER EATS</span>
+
+<span class="comment"># Ignore formatting differences</span>
+<span class="keyword">match:</span> normalized(<span class="string">"WHOLEFOODS"</span>)
+<span class="comment"># Matches: WHOLE FOODS, WHOLE-FOODS, WHOLEFDS</span>
+
+<span class="comment"># Match multiple patterns</span>
+<span class="keyword">match:</span> anyof(<span class="string">"NETFLIX"</span>, <span class="string">"HULU"</span>, <span class="string">"HBO"</span>)
+
+<span class="comment"># Search custom field</span>
+<span class="keyword">match:</span> contains(field.memo, <span class="string">"REF"</span>)</code></pre>
+
+        <h2 id="conditions">Amount &amp; Date Conditions</h2>
+        <table>
+            <tr>
+                <th>Condition</th>
+                <th>Description</th>
+            </tr>
+            <tr>
+                <td><code>amount &gt; 100</code></td>
+                <td>Transactions over $100</td>
+            </tr>
+            <tr>
+                <td><code>amount &lt;= 50</code></td>
+                <td>Transactions $50 or less</td>
+            </tr>
+            <tr>
+                <td><code>amount &lt; 0</code></td>
+                <td>Credits/refunds (negative amounts)</td>
+            </tr>
+            <tr>
+                <td><code>month == 12</code></td>
+                <td>December transactions only</td>
+            </tr>
+            <tr>
+                <td><code>month &gt;= 11</code></td>
+                <td>November and December</td>
+            </tr>
+            <tr>
+                <td><code>year == 2024</code></td>
+                <td>Specific year</td>
+            </tr>
+            <tr>
+                <td><code>day == 1</code></td>
+                <td>First of the month</td>
+            </tr>
+            <tr>
+                <td><code>date &gt;= "2024-01-01"</code></td>
+                <td>On or after a specific date</td>
+            </tr>
+        </table>
+
+        <h2 id="combining">Combining Conditions</h2>
+        <table>
+            <tr>
+                <th>Operator</th>
+                <th>Description</th>
+                <th>Example</th>
+            </tr>
+            <tr>
+                <td><code>and</code></td>
+                <td>Both must be true</td>
+                <td><code>contains("COSTCO") and amount &gt; 200</code></td>
+            </tr>
+            <tr>
+                <td><code>or</code></td>
+                <td>Either can be true</td>
+                <td><code>contains("SHELL") or contains("CHEVRON")</code></td>
+            </tr>
+            <tr>
+                <td><code>not</code></td>
+                <td>Negates condition</td>
+                <td><code>contains("UBER") and not contains("EATS")</code></td>
+            </tr>
+            <tr>
+                <td><code>( )</code></td>
+                <td>Group conditions</td>
+                <td><code>(contains("AMAZON") or contains("AMZN")) and amount &gt; 100</code></td>
+            </tr>
+        </table>
+
+        <h2 id="custom-fields">Custom CSV Fields</h2>
+        <p>Access fields captured from CSV format strings using <code>field.&lt;name&gt;</code>:</p>
+        <pre><code><span class="comment"># In settings.yaml:</span>
+<span class="keyword">format:</span> <span class="string">"{date},{txn_type},{memo},{vendor},{amount}"</span>
+<span class="keyword">columns:</span>
+  <span class="keyword">description:</span> <span class="string">"{vendor}"</span>
+
+<span class="comment"># In merchants.rules:</span>
+<span class="highlight">[Wire Transfer]</span>
+<span class="keyword">match:</span> field.txn_type == <span class="string">"WIRE"</span>
+<span class="keyword">category:</span> Transfers
+
+<span class="highlight">[Invoice Payment]</span>
+<span class="keyword">match:</span> contains(field.memo, <span class="string">"Invoice"</span>)
+<span class="keyword">category:</span> Bills</code></pre>
+
+        <p>Use <code>exists(field.name)</code> to safely check if a field exists:</p>
+        <pre><code><span class="keyword">match:</span> exists(field.memo) and contains(field.memo, <span class="string">"REF"</span>)</code></pre>
+
+        <h2 id="extraction">Extraction Functions</h2>
+        <table>
+            <tr>
+                <th>Function</th>
+                <th>Description</th>
+            </tr>
+            <tr>
+                <td><code>extract("pattern")</code></td>
+                <td>Extract first regex capture group</td>
+            </tr>
+            <tr>
+                <td><code>split("-", 0)</code></td>
+                <td>Split by delimiter, get element at index</td>
+            </tr>
+            <tr>
+                <td><code>substring(0, 4)</code></td>
+                <td>Extract substring by position</td>
+            </tr>
+            <tr>
+                <td><code>trim()</code></td>
+                <td>Remove leading/trailing whitespace</td>
+            </tr>
+            <tr>
+                <td><code>exists(field.x)</code></td>
+                <td>Check if field exists and is non-empty</td>
+            </tr>
+        </table>
+
+        <h2 id="variables">Variables</h2>
+        <p>Define reusable conditions at the top of your file:</p>
+        <pre><code><span class="comment"># Define variables</span>
+is_large = amount &gt; 500
+is_holiday = month &gt;= 11 and month &lt;= 12
+is_coffee = anyof(<span class="string">"STARBUCKS"</span>, <span class="string">"PEETS"</span>, <span class="string">"PHILZ"</span>)
+
+<span class="comment"># Use in rules</span>
+<span class="highlight">[Holiday Splurge]</span>
+<span class="keyword">match:</span> is_large and is_holiday
+<span class="keyword">category:</span> Shopping</code></pre>
+
+        <h2 id="transforms">Field Transforms</h2>
+        <p>Mutate field values before matching. Place at the top of your file:</p>
+        <pre><code><span class="comment"># Strip common prefixes</span>
+field.description = regex_replace(field.description, <span class="string">"^APLPAY\\s+"</span>, <span class="string">""</span>)
+field.description = regex_replace(field.description, <span class="string">"^SQ\\*\\s*"</span>, <span class="string">""</span>)
+field.memo = trim(field.memo)</code></pre>
+
+        <table>
+            <tr>
+                <th>Function</th>
+                <th>Description</th>
+            </tr>
+            <tr>
+                <td><code>regex_replace(text, pattern, repl)</code></td>
+                <td>Regex substitution (replaces all matches)</td>
+            </tr>
+            <tr>
+                <td><code>uppercase(text)</code></td>
+                <td>Convert to uppercase</td>
+            </tr>
+            <tr>
+                <td><code>lowercase(text)</code></td>
+                <td>Convert to lowercase</td>
+            </tr>
+            <tr>
+                <td><code>strip_prefix(text, prefix)</code></td>
+                <td>Remove prefix (case-insensitive)</td>
+            </tr>
+            <tr>
+                <td><code>strip_suffix(text, suffix)</code></td>
+                <td>Remove suffix (case-insensitive)</td>
+            </tr>
+            <tr>
+                <td><code>trim(text)</code></td>
+                <td>Remove leading/trailing whitespace</td>
+            </tr>
+        </table>
+
+        <div class="note">
+            <div class="note-title">Note</div>
+            <p>Original values are preserved in <code>_raw_&lt;field&gt;</code> (e.g., <code>_raw_description</code>).</p>
+        </div>
+
+        <h2 id="special-tags">Special Tags</h2>
+        <p>These tags have special meaning in the spending report:</p>
+        <table>
+            <tr>
+                <th>Tag</th>
+                <th>Effect</th>
+            </tr>
+            <tr>
+                <td><code>income</code></td>
+                <td>Excluded from spending totals (salary, deposits)</td>
+            </tr>
+            <tr>
+                <td><code>transfer</code></td>
+                <td>Excluded from spending totals (CC payments, transfers)</td>
+            </tr>
+            <tr>
+                <td><code>refund</code></td>
+                <td>Shown in "Credits Applied" section, nets against spending</td>
+            </tr>
+        </table>
+
+        <h2 id="dynamic-tags">Dynamic Tags</h2>
+        <p>Use <code>{expression}</code> to create tags from field values:</p>
+        <pre><code><span class="highlight">[Bank Transaction]</span>
+<span class="keyword">match:</span> contains(<span class="string">"BANK"</span>)
+<span class="keyword">category:</span> Transfers
+<span class="keyword">tags:</span> banking, {field.txn_type}     <span class="comment"># → "banking", "wire" or "ach"</span>
+
+<span class="highlight">[All Purchases]</span>
+<span class="keyword">match:</span> *
+<span class="keyword">tags:</span> {source}                      <span class="comment"># → "alice-amex", "bob-chase", etc.</span></code></pre>
+
+        <h2 id="tag-only-rules">Tag-Only Rules</h2>
+        <p>Rules without <code>category:</code> add tags without affecting categorization:</p>
+        <pre><code><span class="highlight">[Large Purchase]</span>
+<span class="keyword">match:</span> amount &gt; 500
+<span class="keyword">tags:</span> large, review              <span class="comment"># No category - just adds tags</span>
+
+<span class="highlight">[Holiday Season]</span>
+<span class="keyword">match:</span> month &gt;= 11 and month &lt;= 12
+<span class="keyword">tags:</span> holiday</code></pre>
+
+        <div class="note">
+            <div class="note-title">Two-pass matching</div>
+            <p>First rule with <code>category:</code> sets the category. Tags are collected from ALL matching rules.</p>
+        </div>
+
+        <h2 id="rule-priority">Rule Priority</h2>
+        <p>First categorization rule wins. Put specific patterns before general ones:</p>
+        <pre><code><span class="highlight">[Uber Eats]</span>                    <span class="comment"># More specific, checked first</span>
+<span class="keyword">match:</span> contains(<span class="string">"UBER EATS"</span>)
+<span class="keyword">category:</span> Food
+
+<span class="highlight">[Uber Rides]</span>                   <span class="comment"># Less specific, checked second</span>
+<span class="keyword">match:</span> contains(<span class="string">"UBER"</span>)
+<span class="keyword">category:</span> Transportation</code></pre>
+
+        <h2 id="views-rules">Views Rules</h2>
+        <p>File: <code>config/views.rules</code></p>
+        <p>Create custom sections in the spending report.</p>
+
+        <h3>View Structure</h3>
+        <pre><code><span class="highlight">[View Name]</span>                <span class="comment"># Section header in report</span>
+<span class="keyword">description:</span> &lt;text&gt;        <span class="comment"># Optional: subtitle under header</span>
+<span class="keyword">filter:</span> &lt;expression&gt;       <span class="comment"># Required: which merchants to include</span></code></pre>
+
+        <h3>Filter Primitives</h3>
+        <table>
+            <tr>
+                <th>Name</th>
+                <th>Type</th>
+                <th>Description</th>
+            </tr>
+            <tr>
+                <td><code>months</code></td>
+                <td>int</td>
+                <td>Number of months with transactions</td>
+            </tr>
+            <tr>
+                <td><code>payments</code></td>
+                <td>int</td>
+                <td>Total number of transactions</td>
+            </tr>
+            <tr>
+                <td><code>total</code></td>
+                <td>float</td>
+                <td>Total spending for this merchant</td>
+            </tr>
+            <tr>
+                <td><code>cv</code></td>
+                <td>float</td>
+                <td>Coefficient of variation (0 = consistent)</td>
+            </tr>
+            <tr>
+                <td><code>category</code></td>
+                <td>str</td>
+                <td>Merchant category</td>
+            </tr>
+            <tr>
+                <td><code>subcategory</code></td>
+                <td>str</td>
+                <td>Merchant subcategory</td>
+            </tr>
+            <tr>
+                <td><code>tags</code></td>
+                <td>set</td>
+                <td>Merchant tags (use <code>has</code> to check)</td>
+            </tr>
+        </table>
+
+        <h2 id="view-functions">View Functions</h2>
+        <table>
+            <tr>
+                <th>Function</th>
+                <th>Description</th>
+            </tr>
+            <tr>
+                <td><code>sum()</code>, <code>avg()</code>, <code>count()</code></td>
+                <td>Aggregation functions</td>
+            </tr>
+            <tr>
+                <td><code>min()</code>, <code>max()</code>, <code>stddev()</code></td>
+                <td>Statistical functions</td>
+            </tr>
+            <tr>
+                <td><code>by("month")</code></td>
+                <td>Group transactions by month</td>
+            </tr>
+            <tr>
+                <td><code>by("year")</code></td>
+                <td>Group transactions by year</td>
+            </tr>
+        </table>
+
+        <h3>Grouping with by()</h3>
+        <pre><code><span class="comment"># Monthly grouping</span>
+by(<span class="string">"month"</span>)              <span class="comment"># [[100, 200], [150], [175, 125]] - grouped payments</span>
+sum(by(<span class="string">"month"</span>))         <span class="comment"># [300, 150, 300] - monthly totals</span>
+avg(sum(by(<span class="string">"month"</span>)))    <span class="comment"># 250 - average monthly spend</span>
+max(sum(by(<span class="string">"month"</span>)))    <span class="comment"># 300 - highest spending month</span></code></pre>
+
+        <h3>View Examples</h3>
+        <pre><code><span class="highlight">[Every Month]</span>
+<span class="keyword">description:</span> Consistent recurring (rent, utilities, subscriptions)
+<span class="keyword">filter:</span> months &gt;= 6 and cv &lt; 0.3
+
+<span class="highlight">[Variable Recurring]</span>
+<span class="keyword">description:</span> Frequent but inconsistent (groceries, shopping)
+<span class="keyword">filter:</span> months &gt;= 6 and cv &gt;= 0.3
+
+<span class="highlight">[Large Purchases]</span>
+<span class="keyword">description:</span> Big one-time expenses
+<span class="keyword">filter:</span> total &gt; 1000 and months &lt;= 2
+
+<span class="highlight">[Business]</span>
+<span class="keyword">description:</span> Expenses to submit for reimbursement
+<span class="keyword">filter:</span> tags has <span class="string">"business"</span>
+
+<span class="highlight">[Streaming]</span>
+<span class="keyword">filter:</span> category == <span class="string">"Subscriptions"</span> and subcategory == <span class="string">"Streaming"</span></code></pre>
+
+        <div class="note">
+            <div class="note-title">Views vs Categories</div>
+            <p><strong>Categories</strong> (in merchants.rules) define WHAT a transaction is. Each transaction has exactly one category.<br>
+            <strong>Views</strong> (in views.rules) define HOW to group for reporting. Same merchant can appear in multiple views.</p>
+        </div>
+    </div>
+</body>
+</html>

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -22,4 +22,28 @@
             <image:title>Tally Logo</image:title>
         </image:image>
     </url>
+    <url>
+        <loc>https://tallyai.money/quickstart.html</loc>
+        <lastmod>2026-01-01</lastmod>
+        <changefreq>monthly</changefreq>
+        <priority>0.9</priority>
+    </url>
+    <url>
+        <loc>https://tallyai.money/guide.html</loc>
+        <lastmod>2026-01-01</lastmod>
+        <changefreq>monthly</changefreq>
+        <priority>0.8</priority>
+    </url>
+    <url>
+        <loc>https://tallyai.money/reference.html</loc>
+        <lastmod>2026-01-01</lastmod>
+        <changefreq>monthly</changefreq>
+        <priority>0.8</priority>
+    </url>
+    <url>
+        <loc>https://tallyai.money/formats.html</loc>
+        <lastmod>2026-01-01</lastmod>
+        <changefreq>monthly</changefreq>
+        <priority>0.8</priority>
+    </url>
 </urlset>


### PR DESCRIPTION
## Summary
- Add comprehensive documentation pages to the website
- Simplify README to point to website docs
- Document all format string features including delimiters and travel detection

## New Pages
- **quickstart.html** - 6-step getting started guide
- **guide.html** - Using Tally with AI assistants  
- **reference.html** - merchants.rules and views.rules syntax
- **formats.html** - settings.yaml, format strings, delimiters

## Test plan
- [ ] Verify navigation works between all pages
- [ ] Check all code examples render correctly
- [ ] Test on mobile viewport

Closes #48

🤖 Generated with [Claude Code](https://claude.com/claude-code)