### PR TITLE
Fix single-char delimiter handling.

### DIFF
--- a/config/settings.yaml.example
+++ b/config/settings.yaml.example
@@ -22,11 +22,12 @@ data_sources:
   - name: BOA
     file: data/boa-checking.txt
     type: boa
-  # European format example:
-  # - name: Deutsche Bank
-  #   file: data/deutsche.csv
-  #   format: "{date:%d.%m.%Y},{description},{amount}"
-  #   decimal_separator: ","  # 1.234,56 format
+  # European format example (semicolon-delimited with comma decimals):
+  # - name: European Bank
+  #   file: data/export.csv
+  #   format: "{date:%d-%m-%Y},{description},{amount}"
+  #   delimiter: ";"           # Semicolon-separated columns
+  #   decimal: ","             # 1.234,56 format (comma = decimal, period = thousands)
 
   # Multi-column description example:
   # Some banks split transaction info across columns (e.g., type + recipient).

--- a/docs/formats.html
+++ b/docs/formats.html
@@ -275,7 +275,7 @@
             <tr>
                 <td><code>delimiter</code></td>
                 <td>No</td>
-                <td>Column delimiter: <code>tab</code>, <code>whitespace</code>, or <code>regex:pattern</code></td>
+                <td>Column delimiter: <code>;</code> or other single char, <code>tab</code>, or <code>regex:pattern</code></td>
             </tr>
             <tr>
                 <td><code>has_header</code></td>

--- a/src/tally/parsers.py
+++ b/src/tally/parsers.py
@@ -153,13 +153,15 @@ def _iter_rows_with_delimiter(filepath, delimiter, has_header):
 
     Args:
         filepath: Path to the file
-        delimiter: None for CSV, 'tab' for TSV, or 'regex:pattern' for regex
+        delimiter: None for CSV, 'tab' for TSV, single char (e.g. ';'), or 'regex:pattern'
         has_header: Whether to skip the first line
 
     Yields:
         List of column values for each row
     """
     with open(filepath, 'r', encoding='utf-8') as f:
+        if delimiter and delimiter == 'tab':
+            delimiter = '\t'
         if delimiter and delimiter.startswith('regex:'):
             # Regex-based parsing
             pattern = re.compile(delimiter[6:])  # Strip 'regex:' prefix
@@ -172,9 +174,8 @@ def _iter_rows_with_delimiter(filepath, delimiter, has_header):
                 match = pattern.match(line)
                 if match:
                     yield list(match.groups())
-        elif delimiter == 'tab' or delimiter == '\t':
-            # Tab-separated
-            reader = csv.reader(f, delimiter='\t')
+        elif delimiter and len(delimiter) == 1:
+            reader = csv.reader(f, delimiter=delimiter)
             if has_header:
                 next(reader, None)
             for row in reader:


### PR DESCRIPTION
Previously, this was ignored and fell through to the standard CSV parsing logic.