### PR TITLE
Support folder and glob CSV sources across commands

### DIFF
--- a/config/settings.yaml.example
+++ b/config/settings.yaml.example
@@ -22,6 +22,13 @@ data_sources:
   - name: BOA
     file: data/boa-checking.txt
     type: boa
+  # Folder + glob examples (CSV only):
+  # - name: Exports (top-level only)
+  #   file: data/exports/          # loads all *.csv in this folder
+  # - name: Monthly Exports
+  #   file: data/exports/*.csv     # top-level glob
+  # - name: All Exports (recursive)
+  #   file: data/exports/**/*.csv  # recursive glob
   # European format example (semicolon-delimited with comma decimals):
   # - name: European Bank
   #   file: data/export.csv

--- a/src/tally/commands/discover.py
+++ b/src/tally/commands/discover.py
@@ -13,6 +13,7 @@ from ..cli_utils import (
     warn_deprecated_parser,
     print_deprecation_warnings,
 )
+from ..path_utils import resolve_data_source_paths
 from ..config_loader import load_config
 from ..merchant_utils import get_all_rules, get_transforms
 from ..analyzer import parse_amex, parse_boa, parse_generic_csv
@@ -59,36 +60,32 @@ def cmd_discover(args):
     all_txns = []
 
     for source in data_sources:
-        filepath = os.path.join(config_dir, '..', source['file'])
-        filepath = os.path.normpath(filepath)
-
-        if not os.path.exists(filepath):
-            filepath = os.path.join(os.path.dirname(config_dir), source['file'])
-
-        if not os.path.exists(filepath):
+        source_files, _ = resolve_data_source_paths(config_dir, source.get('file'))
+        if not source_files:
             continue
 
         parser_type = source.get('_parser_type', source.get('type', '')).lower()
         format_spec = source.get('_format_spec')
 
-        try:
-            if parser_type == 'amex':
-                warn_deprecated_parser(source.get('name', 'AMEX'), 'amex', source['file'])
-                txns = parse_amex(filepath, rules)
-            elif parser_type == 'boa':
-                warn_deprecated_parser(source.get('name', 'BOA'), 'boa', source['file'])
-                txns = parse_boa(filepath, rules)
-            elif parser_type == 'generic' and format_spec:
-                txns = parse_generic_csv(filepath, format_spec, rules,
-                                         source_name=source.get('name', 'CSV'),
-                                         decimal_separator=source.get('decimal_separator', '.'),
-                                         transforms=transforms)
-            else:
+        for filepath in source_files:
+            try:
+                if parser_type == 'amex':
+                    warn_deprecated_parser(source.get('name', 'AMEX'), 'amex', filepath)
+                    txns = parse_amex(filepath, rules)
+                elif parser_type == 'boa':
+                    warn_deprecated_parser(source.get('name', 'BOA'), 'boa', filepath)
+                    txns = parse_boa(filepath, rules)
+                elif parser_type == 'generic' and format_spec:
+                    txns = parse_generic_csv(filepath, format_spec, rules,
+                                             source_name=source.get('name', 'CSV'),
+                                             decimal_separator=source.get('decimal_separator', '.'),
+                                             transforms=transforms)
+                else:
+                    break
+            except Exception:
                 continue
-        except Exception:
-            continue
 
-        all_txns.extend(txns)
+            all_txns.extend(txns)
 
     if not all_txns:
         print("Error: No transactions found", file=sys.stderr)

--- a/src/tally/commands/workflow.py
+++ b/src/tally/commands/workflow.py
@@ -101,6 +101,8 @@ def cmd_workflow(args):
         print(f"       {C.DIM}data_sources:")
         print(f"         - name: My Card")
         print(f"           file: data/transactions.csv")
+        print(f"           {C.DIM}# or: data/exports/*.csv (top-level)")
+        print(f"           {C.DIM}# or: data/exports/**/*.csv (recursive){C.RESET}")
         print(f"           format: \"{{date:%m/%d/%Y}},{{description}},{{amount}}\"{C.RESET}")
         print()
         section("Then: Categorize Transactions")

--- a/src/tally/path_utils.py
+++ b/src/tally/path_utils.py
@@ -1,0 +1,44 @@
+"""
+Path resolution helpers for data sources.
+"""
+
+import glob
+import os
+
+
+def resolve_data_source_paths(config_dir, file_spec):
+    """Resolve a data source file spec into concrete file paths.
+
+    Supports:
+      - Direct file paths
+      - Directory paths (top-level *.csv only)
+      - Glob patterns with * and ** (recursive)
+
+    Returns:
+        (paths, kind) where kind is one of: 'file', 'dir', 'glob', 'missing'
+    """
+    if not file_spec:
+        return [], 'missing'
+
+    base_dir = os.path.dirname(os.path.abspath(config_dir))
+    spec = os.path.expandvars(os.path.expanduser(str(file_spec)))
+    if not os.path.isabs(spec):
+        spec = os.path.normpath(os.path.join(base_dir, spec))
+
+    if glob.has_magic(spec):
+        matches = glob.glob(spec, recursive=True)
+        files = [os.path.normpath(p) for p in matches if os.path.isfile(p)]
+        return sorted(set(files)), 'glob'
+
+    if os.path.isdir(spec):
+        files = []
+        for entry in os.listdir(spec):
+            full_path = os.path.join(spec, entry)
+            if os.path.isfile(full_path) and entry.lower().endswith('.csv'):
+                files.append(os.path.normpath(full_path))
+        return sorted(files), 'dir'
+
+    if os.path.isfile(spec):
+        return [os.path.normpath(spec)], 'file'
+
+    return [], 'missing'

--- a/src/tally/templates.py
+++ b/src/tally/templates.py
@@ -21,6 +21,14 @@ data_sources:
   # - name: Checking
   #   file: data/checking.csv
   #   format: "{{date:%Y-%m-%d}},{{description}},{{-amount}}"
+  #
+  # Folder + glob examples (CSV only):
+  # - name: Exports (top-level only)
+  #   file: data/exports/          # loads all *.csv in this folder
+  # - name: Monthly Exports
+  #   file: data/exports/*.csv     # top-level glob
+  # - name: All Exports (recursive)
+  #   file: data/exports/**/*.csv  # recursive glob
 
 output_dir: output
 html_filename: spending_summary.html


### PR DESCRIPTION
- Resolve file: entries for dirs, *, and ** globs
- Apply expansion to run/explain/discover/diag and supplemental loading
- Document new patterns and add CLI tests

This allows me to download a new CSV file per period from my bank, drop it in a folder, without having to think about merging files, or overwriting old data. As some of my banks have headers in the CSV files, I can't just concatenate files either.
