### PR TITLE
Fix incorrect category display in report for same merchant names

### DIFF
--- a/src/tally/analyzer.py
+++ b/src/tally/analyzer.py
@@ -15,7 +15,6 @@ from .classification import (
     normalize_amount,
     calculate_cash_flow,
     calculate_transfers_net,
-    is_excluded_from_spending,
 )
 
 # Import parsing functions from parsers module (and re-export for backwards compatibility)
@@ -40,6 +39,16 @@ from .report import (
 
 
 # ============================================================================
+
+
+def _get_merchant_display_name(merchant_key, data):
+    """Return the logical merchant name for string or tuple by_merchant keys."""
+    merchant_name = data.get('name')
+    if merchant_name:
+        return merchant_name
+    if isinstance(merchant_key, tuple) and merchant_key:
+        return merchant_key[0]
+    return str(merchant_key)
 
 
 def analyze_transactions(transactions):
@@ -212,7 +221,7 @@ def classify_by_sections(by_merchant, sections_config, num_months=12):
     Classify merchants into user-defined sections.
 
     Args:
-        by_merchant: Dict of merchant_name -> merchant data (from analyze_transactions)
+        by_merchant: Dict of string or tuple merchant keys -> merchant data
         sections_config: SectionConfig from section_engine
         num_months: Number of months in the data period
 
@@ -229,11 +238,7 @@ def classify_by_sections(by_merchant, sections_config, num_months=12):
     # Convert by_merchant to the format expected by section_engine
     merchant_groups = []
     for merchant_key, data in by_merchant.items():
-        merchant_name = data.get('name', '')
-        # Skip merchants excluded from spending (income, transfer, investment)
-        # They appear on their respective cards, not in spending sections
-        if is_excluded_from_spending(list(data.get('tags', []))):
-            continue
+        merchant_name = _get_merchant_display_name(merchant_key, data)
 
         # Build transactions list for the section filter
         # The 'transactions' key already has the individual transactions
@@ -440,15 +445,19 @@ def export_json(stats, verbose=0, category_filter=None, merchant_filter=None):
             if data['total'] > 0
         ],
         'credits': [
-            {'merchant': data.get('name', ''), 'category': data.get('category', ''), 'amount': round(abs(data['total']), 2)}
-            for data in by_merchant.values() if data['total'] < 0
+            {
+                'merchant': _get_merchant_display_name(merchant_key, data),
+                'category': data.get('category', ''),
+                'amount': round(abs(data['total']), 2)
+            }
+            for merchant_key, data in by_merchant.items() if data['total'] < 0
         ],
         'merchants': []
     }
 
     merchants = []
-    for data in by_merchant.values():
-        merchant_name = data.get('name', '')
+    for merchant_key, data in by_merchant.items():
+        merchant_name = _get_merchant_display_name(merchant_key, data)
         # Apply filters
         if category_filter and data.get('category') != category_filter:
             continue
@@ -532,7 +541,10 @@ def export_markdown(stats, verbose=0, category_filter=None, merchant_filter=None
         lines.append('')
 
     # Credits/Refunds
-    credit_merchants = [(d.get('name', ''), d) for d in by_merchant.values() if d['total'] < 0]
+    credit_merchants = [
+        (_get_merchant_display_name(merchant_key, data), data)
+        for merchant_key, data in by_merchant.items() if data['total'] < 0
+    ]
     if credit_merchants:
         lines.append('## Credits/Refunds\n')
         lines.append('| Merchant | Category | Amount |')
@@ -556,7 +568,10 @@ def export_markdown(stats, verbose=0, category_filter=None, merchant_filter=None
     lines.append("## Merchants\n")
 
     # Sort by monthly value (positive merchants only)
-    positive_merchants = [(d.get('name', ''), d) for d in by_merchant.values() if d['total'] > 0]
+    positive_merchants = [
+        (_get_merchant_display_name(merchant_key, data), data)
+        for merchant_key, data in by_merchant.items() if data['total'] > 0
+    ]
     sorted_merchants = sorted(
         positive_merchants,
         key=lambda x: x[1].get('monthly_value', 0),
@@ -616,8 +631,8 @@ def export_csv(stats, category_filter=None, merchant_filter=None):
     all_transactions = []
     extra_field_names = set()
 
-    for _merchant_key, data in by_merchant.items():
-        merchant_name = data.get('name', '')
+    for merchant_key, data in by_merchant.items():
+        merchant_name = _get_merchant_display_name(merchant_key, data)
         # Apply filters
         if category_filter and data.get('category') != category_filter:
             continue
@@ -734,7 +749,10 @@ def print_summary(stats, title=None, filter_category=None, currency_format="${am
     # =========================================================================
     # CREDITS/REFUNDS (if any negative totals)
     # =========================================================================
-    credit_merchants = [(d.get('name', ''), d) for d in by_merchant.values() if d['total'] < 0]
+    credit_merchants = [
+        (_get_merchant_display_name(merchant_key, data), data)
+        for merchant_key, data in by_merchant.items() if data['total'] < 0
+    ]
     if credit_merchants:
         print("\n" + "=" * 80)
         print("CREDITS/REFUNDS")
@@ -773,7 +791,10 @@ def print_summary(stats, title=None, filter_category=None, currency_format="${am
     print("-" * 80)
 
     # Only show positive-total merchants here (credits shown separately)
-    positive_merchants = [(d.get('name', ''), d) for d in by_merchant.values() if d['total'] > 0]
+    positive_merchants = [
+        (_get_merchant_display_name(merchant_key, data), data)
+        for merchant_key, data in by_merchant.items() if data['total'] > 0
+    ]
     sorted_merchants = sorted(
         positive_merchants,
         key=lambda x: x[1].get('total', 0),
@@ -824,7 +845,7 @@ def print_summary(stats, title=None, filter_category=None, currency_format="${am
             cat = data.get('category', 'Unknown')
             if cat not in cat_merchants:
                 cat_merchants[cat] = []
-            cat_merchants[cat].append((data.get('name', ''), data))
+            cat_merchants[cat].append((_get_merchant_display_name(_merchant_key, data), data))
 
         # Sort categories by total
         sorted_cats = sorted(

--- a/src/tally/analyzer.py
+++ b/src/tally/analyzer.py
@@ -15,6 +15,7 @@ from .classification import (
     normalize_amount,
     calculate_cash_flow,
     calculate_transfers_net,
+    is_excluded_from_spending,
 )
 
 # Import parsing functions from parsers module (and re-export for backwards compatibility)
@@ -45,6 +46,7 @@ def analyze_transactions(transactions):
     """Analyze transactions and return summary statistics."""
     by_category = defaultdict(lambda: {'count': 0, 'total': 0})
     by_merchant = defaultdict(lambda: {
+        'name': '',
         'count': 0,
         'total': 0,
         'category': '',
@@ -88,14 +90,17 @@ def analyze_transactions(transactions):
 
         month_key = txn['date'].strftime('%Y-%m')
 
-        # Track by merchant
-        by_merchant[txn['merchant']]['count'] += 1
-        by_merchant[txn['merchant']]['total'] += effective_amount
-        by_merchant[txn['merchant']]['category'] = txn['category']
-        by_merchant[txn['merchant']]['subcategory'] = txn['subcategory']
-        by_merchant[txn['merchant']]['months'].add(month_key)
-        by_merchant[txn['merchant']]['monthly_amounts'][month_key] += effective_amount
-        by_merchant[txn['merchant']]['payments'].append(effective_amount)
+        # Track by merchant - use composite key (merchant, category, subcategory)
+        # so same-named merchants with different categories appear as separate rows
+        merchant_key = (txn['merchant'], txn['category'], txn['subcategory'])
+        by_merchant[merchant_key]['name'] = txn['merchant']
+        by_merchant[merchant_key]['count'] += 1
+        by_merchant[merchant_key]['total'] += effective_amount
+        by_merchant[merchant_key]['category'] = txn['category']
+        by_merchant[merchant_key]['subcategory'] = txn['subcategory']
+        by_merchant[merchant_key]['months'].add(month_key)
+        by_merchant[merchant_key]['monthly_amounts'][month_key] += effective_amount
+        by_merchant[merchant_key]['payments'].append(effective_amount)
         txn_data = {
             'date': txn['date'].strftime('%m/%d'),
             'month': month_key,
@@ -111,18 +116,18 @@ def analyze_transactions(transactions):
         # Include original_description if transform was applied
         if txn.get('original_description'):
             txn_data['original_description'] = txn['original_description']
-        by_merchant[txn['merchant']]['transactions'].append(txn_data)
+        by_merchant[merchant_key]['transactions'].append(txn_data)
         # Track max payment
-        if effective_amount > by_merchant[txn['merchant']]['max_payment']:
-            by_merchant[txn['merchant']]['max_payment'] = effective_amount
+        if effective_amount > by_merchant[merchant_key]['max_payment']:
+            by_merchant[merchant_key]['max_payment'] = effective_amount
         # Store match info (pattern that matched) - first transaction sets this
-        if 'match_info' not in by_merchant[txn['merchant']] and txn.get('match_info'):
-            by_merchant[txn['merchant']]['match_info'] = txn['match_info']
+        if 'match_info' not in by_merchant[merchant_key] and txn.get('match_info'):
+            by_merchant[merchant_key]['match_info'] = txn['match_info']
         # Collect tags from all transactions
-        by_merchant[txn['merchant']]['tags'].update(txn.get('tags', []))
+        by_merchant[merchant_key]['tags'].update(txn.get('tags', []))
         # Track raw description variations
         raw_desc = txn.get('raw_description', txn.get('description', ''))
-        by_merchant[txn['merchant']]['raw_descriptions'][raw_desc] += 1
+        by_merchant[merchant_key]['raw_descriptions'][raw_desc] += 1
 
         by_month[month_key] += effective_amount
 
@@ -223,7 +228,12 @@ def classify_by_sections(by_merchant, sections_config, num_months=12):
 
     # Convert by_merchant to the format expected by section_engine
     merchant_groups = []
-    for merchant_name, data in by_merchant.items():
+    for merchant_key, data in by_merchant.items():
+        merchant_name = data.get('name', '')
+        # Skip merchants excluded from spending (income, transfer, investment)
+        # They appear on their respective cards, not in spending sections
+        if is_excluded_from_spending(list(data.get('tags', []))):
+            continue
 
         # Build transactions list for the section filter
         # The 'transactions' key already has the individual transactions
@@ -430,21 +440,22 @@ def export_json(stats, verbose=0, category_filter=None, merchant_filter=None):
             if data['total'] > 0
         ],
         'credits': [
-            {'merchant': name, 'category': data.get('category', ''), 'amount': round(abs(data['total']), 2)}
-            for name, data in by_merchant.items() if data['total'] < 0
+            {'merchant': data.get('name', ''), 'category': data.get('category', ''), 'amount': round(abs(data['total']), 2)}
+            for data in by_merchant.values() if data['total'] < 0
         ],
         'merchants': []
     }
 
     merchants = []
-    for name, data in by_merchant.items():
+    for data in by_merchant.values():
+        merchant_name = data.get('name', '')
         # Apply filters
         if category_filter and data.get('category') != category_filter:
             continue
-        if merchant_filter and name not in merchant_filter:
+        if merchant_filter and merchant_name not in merchant_filter:
             continue
 
-        merchants.append(build_merchant_json(name, data, verbose))
+        merchants.append(build_merchant_json(merchant_name, data, verbose))
 
     # Sort by monthly value descending
     merchants.sort(key=lambda x: x['monthly_value'], reverse=True)
@@ -521,7 +532,7 @@ def export_markdown(stats, verbose=0, category_filter=None, merchant_filter=None
         lines.append('')
 
     # Credits/Refunds
-    credit_merchants = [(m, d) for m, d in by_merchant.items() if d['total'] < 0]
+    credit_merchants = [(d.get('name', ''), d) for d in by_merchant.values() if d['total'] < 0]
     if credit_merchants:
         lines.append('## Credits/Refunds\n')
         lines.append('| Merchant | Category | Amount |')
@@ -545,7 +556,7 @@ def export_markdown(stats, verbose=0, category_filter=None, merchant_filter=None
     lines.append("## Merchants\n")
 
     # Sort by monthly value (positive merchants only)
-    positive_merchants = [(m, d) for m, d in by_merchant.items() if d['total'] > 0]
+    positive_merchants = [(d.get('name', ''), d) for d in by_merchant.values() if d['total'] > 0]
     sorted_merchants = sorted(
         positive_merchants,
         key=lambda x: x[1].get('monthly_value', 0),
@@ -605,7 +616,8 @@ def export_csv(stats, category_filter=None, merchant_filter=None):
     all_transactions = []
     extra_field_names = set()
 
-    for merchant_name, data in by_merchant.items():
+    for _merchant_key, data in by_merchant.items():
+        merchant_name = data.get('name', '')
         # Apply filters
         if category_filter and data.get('category') != category_filter:
             continue
@@ -722,7 +734,7 @@ def print_summary(stats, title=None, filter_category=None, currency_format="${am
     # =========================================================================
     # CREDITS/REFUNDS (if any negative totals)
     # =========================================================================
-    credit_merchants = [(m, d) for m, d in by_merchant.items() if d['total'] < 0]
+    credit_merchants = [(d.get('name', ''), d) for d in by_merchant.values() if d['total'] < 0]
     if credit_merchants:
         print("\n" + "=" * 80)
         print("CREDITS/REFUNDS")
@@ -761,7 +773,7 @@ def print_summary(stats, title=None, filter_category=None, currency_format="${am
     print("-" * 80)
 
     # Only show positive-total merchants here (credits shown separately)
-    positive_merchants = [(m, d) for m, d in by_merchant.items() if d['total'] > 0]
+    positive_merchants = [(d.get('name', ''), d) for d in by_merchant.values() if d['total'] > 0]
     sorted_merchants = sorted(
         positive_merchants,
         key=lambda x: x[1].get('total', 0),
@@ -806,13 +818,13 @@ def print_summary(stats, title=None, filter_category=None, currency_format="${am
 
         # Build category -> merchants mapping
         cat_merchants = {}
-        for merchant, data in by_merchant.items():
+        for _merchant_key, data in by_merchant.items():
             if data['total'] <= 0:
                 continue
             cat = data.get('category', 'Unknown')
             if cat not in cat_merchants:
                 cat_merchants[cat] = []
-            cat_merchants[cat].append((merchant, data))
+            cat_merchants[cat].append((data.get('name', ''), data))
 
         # Sort categories by total
         sorted_cats = sorted(

--- a/src/tally/analyzer.py
+++ b/src/tally/analyzer.py
@@ -46,6 +46,7 @@ def analyze_transactions(transactions):
     """Analyze transactions and return summary statistics."""
     by_category = defaultdict(lambda: {'count': 0, 'total': 0})
     by_merchant = defaultdict(lambda: {
+        'name': '',
         'count': 0,
         'total': 0,
         'category': '',
@@ -89,14 +90,17 @@ def analyze_transactions(transactions):
 
         month_key = txn['date'].strftime('%Y-%m')
 
-        # Track by merchant
-        by_merchant[txn['merchant']]['count'] += 1
-        by_merchant[txn['merchant']]['total'] += effective_amount
-        by_merchant[txn['merchant']]['category'] = txn['category']
-        by_merchant[txn['merchant']]['subcategory'] = txn['subcategory']
-        by_merchant[txn['merchant']]['months'].add(month_key)
-        by_merchant[txn['merchant']]['monthly_amounts'][month_key] += effective_amount
-        by_merchant[txn['merchant']]['payments'].append(effective_amount)
+        # Track by merchant - use composite key (merchant, category, subcategory)
+        # so same-named merchants with different categories appear as separate rows
+        merchant_key = (txn['merchant'], txn['category'], txn['subcategory'])
+        by_merchant[merchant_key]['name'] = txn['merchant']
+        by_merchant[merchant_key]['count'] += 1
+        by_merchant[merchant_key]['total'] += effective_amount
+        by_merchant[merchant_key]['category'] = txn['category']
+        by_merchant[merchant_key]['subcategory'] = txn['subcategory']
+        by_merchant[merchant_key]['months'].add(month_key)
+        by_merchant[merchant_key]['monthly_amounts'][month_key] += effective_amount
+        by_merchant[merchant_key]['payments'].append(effective_amount)
         txn_data = {
             'date': txn['date'].strftime('%m/%d'),
             'month': month_key,
@@ -112,18 +116,18 @@ def analyze_transactions(transactions):
         # Include original_description if transform was applied
         if txn.get('original_description'):
             txn_data['original_description'] = txn['original_description']
-        by_merchant[txn['merchant']]['transactions'].append(txn_data)
+        by_merchant[merchant_key]['transactions'].append(txn_data)
         # Track max payment
-        if effective_amount > by_merchant[txn['merchant']]['max_payment']:
-            by_merchant[txn['merchant']]['max_payment'] = effective_amount
+        if effective_amount > by_merchant[merchant_key]['max_payment']:
+            by_merchant[merchant_key]['max_payment'] = effective_amount
         # Store match info (pattern that matched) - first transaction sets this
-        if 'match_info' not in by_merchant[txn['merchant']] and txn.get('match_info'):
-            by_merchant[txn['merchant']]['match_info'] = txn['match_info']
+        if 'match_info' not in by_merchant[merchant_key] and txn.get('match_info'):
+            by_merchant[merchant_key]['match_info'] = txn['match_info']
         # Collect tags from all transactions
-        by_merchant[txn['merchant']]['tags'].update(txn.get('tags', []))
+        by_merchant[merchant_key]['tags'].update(txn.get('tags', []))
         # Track raw description variations
         raw_desc = txn.get('raw_description', txn.get('description', ''))
-        by_merchant[txn['merchant']]['raw_descriptions'][raw_desc] += 1
+        by_merchant[merchant_key]['raw_descriptions'][raw_desc] += 1
 
         by_month[month_key] += effective_amount
 
@@ -224,7 +228,8 @@ def classify_by_sections(by_merchant, sections_config, num_months=12):
 
     # Convert by_merchant to the format expected by section_engine
     merchant_groups = []
-    for merchant_name, data in by_merchant.items():
+    for merchant_key, data in by_merchant.items():
+        merchant_name = data.get('name', '')
         # Skip merchants excluded from spending (income, transfer, investment)
         # They appear on their respective cards, not in spending sections
         if is_excluded_from_spending(list(data.get('tags', []))):
@@ -435,21 +440,22 @@ def export_json(stats, verbose=0, category_filter=None, merchant_filter=None):
             if data['total'] > 0
         ],
         'credits': [
-            {'merchant': name, 'category': data.get('category', ''), 'amount': round(abs(data['total']), 2)}
-            for name, data in by_merchant.items() if data['total'] < 0
+            {'merchant': data.get('name', ''), 'category': data.get('category', ''), 'amount': round(abs(data['total']), 2)}
+            for data in by_merchant.values() if data['total'] < 0
         ],
         'merchants': []
     }
 
     merchants = []
-    for name, data in by_merchant.items():
+    for data in by_merchant.values():
+        merchant_name = data.get('name', '')
         # Apply filters
         if category_filter and data.get('category') != category_filter:
             continue
-        if merchant_filter and name not in merchant_filter:
+        if merchant_filter and merchant_name not in merchant_filter:
             continue
 
-        merchants.append(build_merchant_json(name, data, verbose))
+        merchants.append(build_merchant_json(merchant_name, data, verbose))
 
     # Sort by monthly value descending
     merchants.sort(key=lambda x: x['monthly_value'], reverse=True)
@@ -526,7 +532,7 @@ def export_markdown(stats, verbose=0, category_filter=None, merchant_filter=None
         lines.append('')
 
     # Credits/Refunds
-    credit_merchants = [(m, d) for m, d in by_merchant.items() if d['total'] < 0]
+    credit_merchants = [(d.get('name', ''), d) for d in by_merchant.values() if d['total'] < 0]
     if credit_merchants:
         lines.append('## Credits/Refunds\n')
         lines.append('| Merchant | Category | Amount |')
@@ -550,7 +556,7 @@ def export_markdown(stats, verbose=0, category_filter=None, merchant_filter=None
     lines.append("## Merchants\n")
 
     # Sort by monthly value (positive merchants only)
-    positive_merchants = [(m, d) for m, d in by_merchant.items() if d['total'] > 0]
+    positive_merchants = [(d.get('name', ''), d) for d in by_merchant.values() if d['total'] > 0]
     sorted_merchants = sorted(
         positive_merchants,
         key=lambda x: x[1].get('monthly_value', 0),
@@ -610,7 +616,8 @@ def export_csv(stats, category_filter=None, merchant_filter=None):
     all_transactions = []
     extra_field_names = set()
 
-    for merchant_name, data in by_merchant.items():
+    for _merchant_key, data in by_merchant.items():
+        merchant_name = data.get('name', '')
         # Apply filters
         if category_filter and data.get('category') != category_filter:
             continue
@@ -727,7 +734,7 @@ def print_summary(stats, title=None, filter_category=None, currency_format="${am
     # =========================================================================
     # CREDITS/REFUNDS (if any negative totals)
     # =========================================================================
-    credit_merchants = [(m, d) for m, d in by_merchant.items() if d['total'] < 0]
+    credit_merchants = [(d.get('name', ''), d) for d in by_merchant.values() if d['total'] < 0]
     if credit_merchants:
         print("\n" + "=" * 80)
         print("CREDITS/REFUNDS")
@@ -766,7 +773,7 @@ def print_summary(stats, title=None, filter_category=None, currency_format="${am
     print("-" * 80)
 
     # Only show positive-total merchants here (credits shown separately)
-    positive_merchants = [(m, d) for m, d in by_merchant.items() if d['total'] > 0]
+    positive_merchants = [(d.get('name', ''), d) for d in by_merchant.values() if d['total'] > 0]
     sorted_merchants = sorted(
         positive_merchants,
         key=lambda x: x[1].get('total', 0),
@@ -811,13 +818,13 @@ def print_summary(stats, title=None, filter_category=None, currency_format="${am
 
         # Build category -> merchants mapping
         cat_merchants = {}
-        for merchant, data in by_merchant.items():
+        for _merchant_key, data in by_merchant.items():
             if data['total'] <= 0:
                 continue
             cat = data.get('category', 'Unknown')
             if cat not in cat_merchants:
                 cat_merchants[cat] = []
-            cat_merchants[cat].append((merchant, data))
+            cat_merchants[cat].append((data.get('name', ''), data))
 
         # Sort categories by total
         sorted_cats = sorted(

--- a/src/tally/commands/explain.py
+++ b/src/tally/commands/explain.py
@@ -118,8 +118,8 @@ def cmd_explain(args):
         # Build a lookup from merchant name -> list of data entries
         # (same merchant name may appear with different categories as separate entries)
         name_to_entries = {}
-        for merchant_data in all_merchants.values():
-            merchant_name = merchant_data.get('name', '')
+        for merchant_key, merchant_data in all_merchants.items():
+            merchant_name = _get_merchant_display_name(merchant_key, merchant_data)
             if merchant_name not in name_to_entries:
                 name_to_entries[merchant_name] = []
             name_to_entries[merchant_name].append(merchant_data)
@@ -129,15 +129,23 @@ def cmd_explain(args):
             # Try exact match first
             if merchant_query in name_to_entries:
                 found_any = True
-                for entry in name_to_entries[merchant_query]:
-                    _print_merchant_explanation(merchant_query, entry, args.format, verbose, stats['num_months'], views_config)
+                entries = [(merchant_query, entry) for entry in name_to_entries[merchant_query]]
+                if args.format == 'json':
+                    _print_merchant_matches_json(merchant_query, 'exact', entries, verbose, stats['num_months'], views_config)
+                else:
+                    for name, entry in entries:
+                        _print_merchant_explanation(name, entry, args.format, verbose, stats['num_months'], views_config)
             else:
                 # Try case-insensitive match
                 matches = [n for n in name_to_entries.keys() if n.lower() == merchant_query.lower()]
                 if matches:
                     found_any = True
-                    for entry in name_to_entries[matches[0]]:
-                        _print_merchant_explanation(matches[0], entry, args.format, verbose, stats['num_months'], views_config)
+                    entries = [(matches[0], entry) for entry in name_to_entries[matches[0]]]
+                    if args.format == 'json':
+                        _print_merchant_matches_json(merchant_query, 'case_insensitive', entries, verbose, stats['num_months'], views_config)
+                    else:
+                        for name, entry in entries:
+                            _print_merchant_explanation(name, entry, args.format, verbose, stats['num_months'], views_config)
                     continue
 
                 # Try substring match on merchant names (partial search)
@@ -145,10 +153,17 @@ def cmd_explain(args):
                 partial_matches = [n for n in name_to_entries.keys() if query_lower in n.lower()]
                 if partial_matches:
                     found_any = True
-                    print(f"Merchants matching '{merchant_query}':\n")
-                    for n in sorted(partial_matches):
-                        for entry in name_to_entries[n]:
-                            _print_merchant_explanation(n, entry, args.format, verbose, stats['num_months'], views_config)
+                    entries = [
+                        (name, entry)
+                        for name in sorted(partial_matches)
+                        for entry in name_to_entries[name]
+                    ]
+                    if args.format == 'json':
+                        _print_merchant_matches_json(merchant_query, 'partial', entries, verbose, stats['num_months'], views_config)
+                    else:
+                        print(f"Merchants matching '{merchant_query}':\n")
+                        for name, entry in entries:
+                            _print_merchant_explanation(name, entry, args.format, verbose, stats['num_months'], views_config)
                     continue
 
                 # Search transactions containing the query
@@ -308,7 +323,10 @@ def cmd_explain(args):
 
             if args.format == 'json':
                 import json
-                merchants = [build_merchant_json(data.get('name', ''), data, verbose) for data in matching_merchants.values()]
+                merchants = [
+                    build_merchant_json(_get_merchant_display_name(merchant_key, data), data, verbose)
+                    for merchant_key, data in matching_merchants.items()
+                ]
                 merchants.sort(key=lambda x: x['monthly_value'], reverse=True)
                 output = {'filters': active_filters, 'merchants': merchants}
                 print(json.dumps(output, indent=2))
@@ -398,6 +416,16 @@ def _merchant_has_month(merchant_data, month_filter):
         if txn_month == month_filter:
             return True
     return False
+
+
+def _get_merchant_display_name(merchant_key, merchant_data):
+    """Return the logical merchant name for string or tuple by_merchant keys."""
+    merchant_name = merchant_data.get('name')
+    if merchant_name:
+        return merchant_name
+    if isinstance(merchant_key, tuple) and merchant_key:
+        return merchant_key[0]
+    return str(merchant_key)
 
 
 def _suggest_available_values(by_merchant, has_category, has_tags, has_month):
@@ -675,11 +703,10 @@ def _print_merchant_explanation(name, data, output_format, verbose, num_months, 
     import json
 
     # Get matching views
-    matching_views = _get_matching_views(data, views_config, num_months)
+    merchant_json = _build_merchant_explanation_json(name, data, verbose, num_months, views_config)
+    matching_views = merchant_json['views']
 
     if output_format == 'json':
-        merchant_json = build_merchant_json(name, data, verbose)
-        merchant_json['views'] = matching_views
         print(json.dumps(merchant_json, indent=2))
     elif output_format == 'markdown':
         reasoning = data.get('reasoning', {})
@@ -817,6 +844,30 @@ def _print_merchant_explanation(name, data, output_format, verbose, num_months, 
         print()
 
 
+def _build_merchant_explanation_json(name, data, verbose, num_months, views_config=None):
+    """Build JSON payload for a single merchant explanation."""
+    merchant_json = build_merchant_json(name, data, verbose)
+    merchant_json['views'] = _get_matching_views(data, views_config, num_months)
+    return merchant_json
+
+
+def _print_merchant_matches_json(query, match_mode, entries, verbose, num_months, views_config=None):
+    """Print a single JSON payload for explain merchant match results."""
+    import json
+
+    merchants = [
+        _build_merchant_explanation_json(name, data, verbose, num_months, views_config)
+        for name, data in entries
+    ]
+    payload = {
+        'query': query,
+        'match_mode': match_mode,
+        'matched_names': sorted({merchant['name'] for merchant in merchants}),
+        'merchants': merchants,
+    }
+    print(json.dumps(payload, indent=2))
+
+
 def _print_classification_summary(section, merchants_dict, verbose, num_months):
     """Print summary of merchants in a classification."""
     section_name = section.replace('_', ' ').title()
@@ -825,7 +876,7 @@ def _print_classification_summary(section, merchants_dict, verbose, num_months):
 
     sorted_merchants = sorted(merchants_dict.items(), key=lambda x: x[1].get('monthly_value', 0), reverse=True)
     for key, data in sorted_merchants:
-        name = data.get('name', str(key))
+        name = _get_merchant_display_name(key, data)
         reasoning = data.get('reasoning', {})
         category = data.get('category', '')
         months = data.get('months_active', 0)
@@ -857,11 +908,11 @@ def _print_explain_summary(stats, verbose):
 
     # Group by category
     by_category = {}
-    for name, data in by_merchant.items():
+    for merchant_key, data in by_merchant.items():
         cat = data.get('category', 'Unknown')
         if cat not in by_category:
             by_category[cat] = []
-        by_category[cat].append((name, data))
+        by_category[cat].append((_get_merchant_display_name(merchant_key, data), data))
 
     # Sort categories by total spend
     sorted_categories = sorted(

--- a/src/tally/commands/explain.py
+++ b/src/tally/commands/explain.py
@@ -115,28 +115,40 @@ def cmd_explain(args):
     # Handle output based on what was requested
     if merchant_names:
         # Explain specific merchants
+        # Build a lookup from merchant name -> list of data entries
+        # (same merchant name may appear with different categories as separate entries)
+        name_to_entries = {}
+        for merchant_data in all_merchants.values():
+            merchant_name = merchant_data.get('name', '')
+            if merchant_name not in name_to_entries:
+                name_to_entries[merchant_name] = []
+            name_to_entries[merchant_name].append(merchant_data)
+
         found_any = False
         for merchant_query in merchant_names:
             # Try exact match first
-            if merchant_query in all_merchants:
+            if merchant_query in name_to_entries:
                 found_any = True
-                _print_merchant_explanation(merchant_query, all_merchants[merchant_query], args.format, verbose, stats['num_months'], views_config)
+                for entry in name_to_entries[merchant_query]:
+                    _print_merchant_explanation(merchant_query, entry, args.format, verbose, stats['num_months'], views_config)
             else:
                 # Try case-insensitive match
-                matches = [m for m in all_merchants.keys() if m.lower() == merchant_query.lower()]
+                matches = [n for n in name_to_entries.keys() if n.lower() == merchant_query.lower()]
                 if matches:
                     found_any = True
-                    _print_merchant_explanation(matches[0], all_merchants[matches[0]], args.format, verbose, stats['num_months'], views_config)
+                    for entry in name_to_entries[matches[0]]:
+                        _print_merchant_explanation(matches[0], entry, args.format, verbose, stats['num_months'], views_config)
                     continue
 
                 # Try substring match on merchant names (partial search)
                 query_lower = merchant_query.lower()
-                partial_matches = [m for m in all_merchants.keys() if query_lower in m.lower()]
+                partial_matches = [n for n in name_to_entries.keys() if query_lower in n.lower()]
                 if partial_matches:
                     found_any = True
                     print(f"Merchants matching '{merchant_query}':\n")
-                    for m in sorted(partial_matches):
-                        _print_merchant_explanation(m, all_merchants[m], args.format, verbose, stats['num_months'], views_config)
+                    for n in sorted(partial_matches):
+                        for entry in name_to_entries[n]:
+                            _print_merchant_explanation(n, entry, args.format, verbose, stats['num_months'], views_config)
                     continue
 
                 # Search transactions containing the query
@@ -182,7 +194,7 @@ def cmd_explain(args):
                     _print_description_explanation(merchant_query, trace, args.format, verbose)
                 else:
                     # Try fuzzy match on merchant names
-                    close_matches = get_close_matches(merchant_query, list(all_merchants.keys()), n=3, cutoff=0.6)
+                    close_matches = get_close_matches(merchant_query, list(name_to_entries.keys()), n=3, cutoff=0.6)
                     if close_matches:
                         print(f"No merchant matching '{merchant_query}'. Did you mean:", file=sys.stderr)
                         for m in close_matches:
@@ -236,7 +248,14 @@ def cmd_explain(args):
                 sys.exit(1)
 
             merchants_list = view_results[view_match]
-            matching_merchants = {name: data for name, data in merchants_list}
+            # Use composite key to avoid collisions when same-named merchants
+            # appear with different categories in the same view
+            matching_merchants = {}
+            for merch_name, data in merchants_list:
+                cat = data.get('category', '')
+                subcat = data.get('subcategory', '')
+                key = (merch_name, cat, subcat)
+                matching_merchants[key] = data
             active_filters.append(f"view:{view_match}")
 
         # Apply category filter
@@ -289,7 +308,7 @@ def cmd_explain(args):
 
             if args.format == 'json':
                 import json
-                merchants = [build_merchant_json(name, data, verbose) for name, data in matching_merchants.items()]
+                merchants = [build_merchant_json(data.get('name', ''), data, verbose) for data in matching_merchants.values()]
                 merchants.sort(key=lambda x: x['monthly_value'], reverse=True)
                 output = {'filters': active_filters, 'merchants': merchants}
                 print(json.dumps(output, indent=2))
@@ -805,7 +824,8 @@ def _print_classification_summary(section, merchants_dict, verbose, num_months):
     print("-" * 50)
 
     sorted_merchants = sorted(merchants_dict.items(), key=lambda x: x[1].get('monthly_value', 0), reverse=True)
-    for name, data in sorted_merchants:
+    for key, data in sorted_merchants:
+        name = data.get('name', str(key))
         reasoning = data.get('reasoning', {})
         category = data.get('category', '')
         months = data.get('months_active', 0)

--- a/src/tally/report.py
+++ b/src/tally/report.py
@@ -4,6 +4,7 @@ HTML Report Generation - Generate spending analysis HTML reports.
 This module handles generation of interactive HTML reports from analyzed transaction data.
 """
 
+import base64
 import json
 import sys
 from collections import defaultdict
@@ -116,19 +117,32 @@ def write_summary_file_vue(stats, filepath, year=None, currency_format="${amount
     by_merchant = stats.get('by_merchant', {})
 
     # Helper function to create merchant IDs
-    def make_merchant_id(name):
-        return name.replace("'", "").replace('"', '').replace(' ', '_')
+    def make_merchant_id(name, category='', subcategory=''):
+        merchant_identity = json.dumps(
+            [name, category, subcategory],
+            ensure_ascii=False,
+            separators=(',', ':'),
+        ).encode('utf-8')
+        encoded_identity = base64.urlsafe_b64encode(merchant_identity).decode('ascii').rstrip('=')
+        return f"merchant_{encoded_identity}"
+
+    def get_merchant_display_name(merchant_key, merchant_data):
+        merchant_name = merchant_data.get('name')
+        if merchant_name:
+            return merchant_name
+        if isinstance(merchant_key, tuple) and merchant_key:
+            return merchant_key[0]
+        return str(merchant_key)
 
     # Build section merchants data
     def build_section_merchants(merchant_dict):
         merchants = {}
         for merchant_key, data in merchant_dict.items():
             # Display name comes from data['name'] when available; fall back to the key
-            merchant_name = data.get('name', merchant_key if isinstance(merchant_key, str) else str(merchant_key))
-            category = data.get('category', '')
-            subcategory = data.get('subcategory', '')
-            # Use a composite ID so same-named merchants with different categories are distinct
-            merchant_id = make_merchant_id(f"{merchant_name}_{category}_{subcategory}")
+            merchant_name = get_merchant_display_name(merchant_key, data)
+            category = data.get('category', merchant_key[1] if isinstance(merchant_key, tuple) and len(merchant_key) > 1 else '')
+            subcategory = data.get('subcategory', merchant_key[2] if isinstance(merchant_key, tuple) and len(merchant_key) > 2 else '')
+            merchant_id = make_merchant_id(merchant_name, category, subcategory)
 
             # Build transactions array with unique IDs
             txns = []
@@ -215,7 +229,7 @@ def write_summary_file_vue(stats, filepath, year=None, currency_format="${amount
             for merch_name, data in merchants_list:
                 cat = data.get('category', '')
                 subcat = data.get('subcategory', '')
-                unique_key = f"{merch_name}||{cat}||{subcat}" if (cat or subcat) else merch_name
+                unique_key = (merch_name, cat, subcat) if (cat or subcat) else merch_name
                 merchant_dict[unique_key] = data
             merchants = build_section_merchants(merchant_dict)
 
@@ -252,11 +266,10 @@ def write_summary_file_vue(stats, filepath, year=None, currency_format="${amount
         all_merchants = {}
         by_merchant = stats.get('by_merchant', {})
         for merchant_key, data in by_merchant.items():
-            merchant_name = data.get('name', '')
+            merchant_name = get_merchant_display_name(merchant_key, data)
             category = data.get('category', '')
             subcategory = data.get('subcategory', '')
-            # Use composite key to ensure uniqueness for same-name merchants in different categories
-            unique_key = f"{merchant_name}||{category}||{subcategory}" if (category or subcategory) else merchant_name
+            unique_key = (merchant_name, category, subcategory) if (category or subcategory) else merchant_name
             sub_result = build_section_merchants({unique_key: data})
             all_merchants.update(sub_result)
 

--- a/src/tally/report.py
+++ b/src/tally/report.py
@@ -122,8 +122,13 @@ def write_summary_file_vue(stats, filepath, year=None, currency_format="${amount
     # Build section merchants data
     def build_section_merchants(merchant_dict):
         merchants = {}
-        for merchant_name, data in merchant_dict.items():
-            merchant_id = make_merchant_id(merchant_name)
+        for merchant_key, data in merchant_dict.items():
+            # Display name comes from data['name'] when available; fall back to the key
+            merchant_name = data.get('name', merchant_key if isinstance(merchant_key, str) else str(merchant_key))
+            category = data.get('category', '')
+            subcategory = data.get('subcategory', '')
+            # Use a composite ID so same-named merchants with different categories are distinct
+            merchant_id = make_merchant_id(f"{merchant_name}_{category}_{subcategory}")
 
             # Build transactions array with unique IDs
             txns = []
@@ -157,8 +162,8 @@ def write_summary_file_vue(stats, filepath, year=None, currency_format="${amount
                     'source': match_info.get('source', ''),
                     'explanation': explain_pattern(pattern),
                     'assignedMerchant': merchant_name,
-                    'assignedCategory': data.get('category', ''),
-                    'assignedSubcategory': data.get('subcategory', ''),
+                    'assignedCategory': category,
+                    'assignedSubcategory': subcategory,
                     'assignedTags': sorted(match_info.get('tags', [])),
                     'tagSources': match_info.get('tag_sources', {}),
                 }
@@ -166,9 +171,9 @@ def write_summary_file_vue(stats, filepath, year=None, currency_format="${amount
             merchants[merchant_id] = {
                 'id': merchant_id,
                 'displayName': merchant_name,
-                'category': data.get('category', 'Other'),
-                'subcategory': data.get('subcategory', 'Uncategorized'),
-                'categoryPath': f"{data.get('category', 'Other')}/{data.get('subcategory', 'Uncategorized')}".lower(),
+                'category': category or 'Other',
+                'subcategory': subcategory or 'Uncategorized',
+                'categoryPath': f"{category or 'Other'}/{subcategory or 'Uncategorized'}".lower(),
                 'calcType': data.get('calc_type', '/12'),
                 'monthsActive': data.get('months_active', 0),
                 'isConsistent': data.get('is_consistent', False),
@@ -204,7 +209,14 @@ def write_summary_file_vue(stats, filepath, year=None, currency_format="${amount
                 continue
 
             # Convert list of (name, data) tuples to dict format
-            merchant_dict = {name: data for name, data in merchants_list}
+            # Use a composite key to avoid collisions when the same merchant name
+            # appears with different categories in the same section
+            merchant_dict = {}
+            for merch_name, data in merchants_list:
+                cat = data.get('category', '')
+                subcat = data.get('subcategory', '')
+                unique_key = f"{merch_name}||{cat}||{subcat}" if (cat or subcat) else merch_name
+                merchant_dict[unique_key] = data
             merchants = build_section_merchants(merchant_dict)
 
             # Add view info to each merchant
@@ -239,9 +251,14 @@ def write_summary_file_vue(stats, filepath, year=None, currency_format="${amount
         # Build from by_merchant which contains ALL merchants (not filtered by sections)
         all_merchants = {}
         by_merchant = stats.get('by_merchant', {})
-        for merchant_name, data in by_merchant.items():
-            merchant_id = make_merchant_id(merchant_name)
-            all_merchants[merchant_id] = build_section_merchants({merchant_name: data})[merchant_id]
+        for merchant_key, data in by_merchant.items():
+            merchant_name = data.get('name', '')
+            category = data.get('category', '')
+            subcategory = data.get('subcategory', '')
+            # Use composite key to ensure uniqueness for same-name merchants in different categories
+            unique_key = f"{merchant_name}||{category}||{subcategory}" if (category or subcategory) else merchant_name
+            sub_result = build_section_merchants({unique_key: data})
+            all_merchants.update(sub_result)
 
         # Group by category -> subcategory
         categories = {}

--- a/src/tally/spending_report.js
+++ b/src/tally/spending_report.js
@@ -193,7 +193,7 @@ const MerchantSection = defineComponent({
                                     @click="toggleExpand(item.id || idx)">
                                     <td class="merchant" :class="{ clickable: categoryMode }">
                                         <span class="chevron">{{ isExpanded(item.id || idx) ? '▼' : '▶' }}</span>
-                                        <span class="merchant-name" @click.stop="categoryMode ? addFilter(item.id, subcategoryMode ? 'subcategory' : 'merchant', item.displayName) : null">
+                                        <span class="merchant-name" @click.stop="categoryMode ? addFilter(subcategoryMode ? item.id : item.displayName, subcategoryMode ? 'subcategory' : 'merchant', item.displayName) : null">
                                             {{ item.displayName || item.merchant }}
                                         </span>
                                         <span v-if="item.matchInfo || item.viewInfo" class="match-info-trigger"
@@ -1217,13 +1217,16 @@ createApp({
             for (const category of Object.values(categoryView)) {
                 for (const subcat of Object.values(category.subcategories || {})) {
                     for (const [id, merchant] of Object.entries(subcat.merchants || {})) {
-                        if (!seenMerchants.has(id)) {
-                            seenMerchants.add(id);
+                        const merchantName = (merchant.displayName || merchant.merchant || '').trim();
+                        const merchantKey = merchantName.toLowerCase();
+                        if (merchantName && !seenMerchants.has(merchantKey)) {
+                            seenMerchants.add(merchantKey);
                             items.push({
                                 type: 'merchant',
-                                filterText: id,
-                                displayText: merchant.displayName,
-                                id: `m:${id}`
+                                // Merchant filter is logical merchant identity, not category-specific row ID.
+                                filterText: merchantName,
+                                displayText: merchantName,
+                                id: `m:${merchantName}`
                             });
                         }
                     }

--- a/src/tally/spending_report.js
+++ b/src/tally/spending_report.js
@@ -925,12 +925,11 @@ createApp({
             for (const cat of Object.values(filteredCategoryView.value)) {
                 for (const subcat of Object.values(cat.filteredSubcategories || cat.subcategories || {})) {
                     for (const merchant of Object.values(subcat.filteredMerchants || subcat.merchants || {})) {
-                        const tags = merchant.tags || [];
                         const txns = merchant.filteredTxns || merchant.transactions || [];
 
                         for (const txn of txns) {
                             // Use centralized categorizeAmount() for consistent classification
-                            const c = categorizeAmount(txn.amount || 0, tags);
+                            const c = categorizeAmount(txn.amount || 0, txn.tags || []);
                             totals.income += c.income;
                             totals.investment += c.investment;
                             totals.transferIn += c.transferIn;
@@ -1097,11 +1096,9 @@ createApp({
             for (const [catName, category] of Object.entries(categoryView)) {
                 for (const subcat of Object.values(category.filteredSubcategories || {})) {
                     for (const merchant of Object.values(subcat.filteredMerchants || {})) {
-                        const tags = merchant.tags || [];
-
                         for (const txn of merchant.filteredTxns || []) {
                             // Use centralized categorization
-                            const c = categorizeAmount(txn.amount, tags);
+                            const c = categorizeAmount(txn.amount, txn.tags || []);
 
                             // Track spending by month and category
                             if (c.spending > 0) {

--- a/src/tally/spending_report.js
+++ b/src/tally/spending_report.js
@@ -193,7 +193,7 @@ const MerchantSection = defineComponent({
                                     @click="toggleExpand(item.id || idx)">
                                     <td class="merchant" :class="{ clickable: categoryMode }">
                                         <span class="chevron">{{ isExpanded(item.id || idx) ? '▼' : '▶' }}</span>
-                                        <span class="merchant-name" @click.stop="categoryMode ? addFilter(item.id, subcategoryMode ? 'subcategory' : 'merchant', item.displayName) : null">
+                                        <span class="merchant-name" @click.stop="categoryMode ? addFilter(subcategoryMode ? item.id : item.displayName, subcategoryMode ? 'subcategory' : 'merchant', item.displayName) : null">
                                             {{ item.displayName || item.merchant }}
                                         </span>
                                         <span v-if="item.matchInfo || item.viewInfo" class="match-info-trigger"
@@ -1203,13 +1203,16 @@ createApp({
             for (const category of Object.values(categoryView)) {
                 for (const subcat of Object.values(category.subcategories || {})) {
                     for (const [id, merchant] of Object.entries(subcat.merchants || {})) {
-                        if (!seenMerchants.has(id)) {
-                            seenMerchants.add(id);
+                        const merchantName = (merchant.displayName || merchant.merchant || '').trim();
+                        const merchantKey = merchantName.toLowerCase();
+                        if (merchantName && !seenMerchants.has(merchantKey)) {
+                            seenMerchants.add(merchantKey);
                             items.push({
                                 type: 'merchant',
-                                filterText: id,
-                                displayText: merchant.displayName,
-                                id: `m:${id}`
+                                // Merchant filter is logical merchant identity, not category-specific row ID.
+                                filterText: merchantName,
+                                displayText: merchantName,
+                                id: `m:${merchantName}`
                             });
                         }
                     }

--- a/tests/test_analyzer.py
+++ b/tests/test_analyzer.py
@@ -11,6 +11,7 @@ from tally.analyzer import parse_generic_csv as _parse_generic_csv
 from tally.parsers import SkippedRow, ParseResult, _detect_date_format
 from tally.format_parser import parse_format_string
 from tally.merchant_utils import get_all_rules
+from tally.report import write_summary_file_vue
 from tally.section_engine import parse_sections
 
 
@@ -432,6 +433,50 @@ class TestExportCsv:
         assert 'paypal_txn_id' in reader.fieldnames
         assert rows[0]['paypal_merchant'] == 'Acme Corp'
         assert rows[0]['paypal_txn_id'] == '123ABC'
+
+
+class TestHtmlReportTupleKeyFallback:
+    """Tests for HTML report generation with tuple by_merchant keys."""
+
+    def test_write_summary_file_vue_falls_back_to_tuple_merchant_name(self, tmp_path):
+        """HTML report should use tuple merchant names when data['name'] is unavailable."""
+        txns = [
+            {
+                'date': date(2025, 1, 5),
+                'description': 'ROCHESTER PUBLIC SCHOOLS CAFE',
+                'raw_description': 'ROCHESTER PUBLIC SCHOOLS CAFE',
+                'merchant': 'Rochester Public Schools',
+                'amount': 42.50,
+                'category': 'Food',
+                'subcategory': 'School Meals',
+                'source': 'test.csv',
+                'tags': [],
+                'excluded': None,
+            },
+            {
+                'date': date(2025, 1, 12),
+                'description': 'ROCHESTER PUBLIC SCHOOLS ACTIVITY FEE',
+                'raw_description': 'ROCHESTER PUBLIC SCHOOLS ACTIVITY FEE',
+                'merchant': 'Rochester Public Schools',
+                'amount': 75.00,
+                'category': 'Education',
+                'subcategory': 'Fees',
+                'source': 'test.csv',
+                'tags': [],
+                'excluded': None,
+            },
+        ]
+
+        stats = analyze_transactions(txns)
+        for data in stats['by_merchant'].values():
+            data.pop('name', None)
+
+        output_path = tmp_path / 'report.html'
+        write_summary_file_vue(stats, output_path, title='Tuple Key Report')
+
+        report_html = output_path.read_text(encoding='utf-8')
+        assert 'Rochester Public Schools' in report_html
+        assert "('Rochester Public Schools', 'Food', 'School Meals')" not in report_html
 
 
 class TestParseAmount:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,5 +1,6 @@
 """Tests for CLI error handling and user experience."""
 
+import json
 import pytest
 import subprocess
 import tempfile
@@ -152,6 +153,51 @@ data_sources:
             assert "No merchants found matching: category:NonExistent" in result.stdout
             assert 'Available categories:' in result.stdout
 
+    def test_explain_summary_handles_tuple_merchant_keys(self):
+        """Default explain summary should render duplicate merchant names without crashing."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config_dir = os.path.join(tmpdir, 'config')
+            data_dir = os.path.join(tmpdir, 'data')
+            os.makedirs(config_dir)
+            os.makedirs(data_dir)
+
+            with open(os.path.join(config_dir, 'settings.yaml'), 'w') as f:
+                f.write("""year: 2025
+data_sources:
+  - name: Test
+    file: data/test.csv
+    format: "{date:%Y-%m-%d},{description},{amount}"
+merchants_file: config/merchants.rules
+""")
+
+            with open(os.path.join(config_dir, 'merchants.rules'), 'w') as f:
+                f.write("""[School Food]
+match: contains("ROCHESTER PUBLIC SCHOOLS CAFE")
+category: Food
+subcategory: School Meals
+merchant: Rochester Public Schools
+
+[School Fees]
+match: contains("ROCHESTER PUBLIC SCHOOLS ACTIVITY")
+category: Education
+subcategory: Fees
+merchant: Rochester Public Schools
+""")
+
+            with open(os.path.join(data_dir, 'test.csv'), 'w') as f:
+                f.write("date,description,amount\n")
+                f.write("2025-01-05,ROCHESTER PUBLIC SCHOOLS CAFE,42.50\n")
+                f.write("2025-01-12,ROCHESTER PUBLIC SCHOOLS ACTIVITY FEE,75.00\n")
+
+            result = subprocess.run(
+                ['uv', 'run', 'tally', 'explain', '--config', config_dir],
+                capture_output=True,
+                text=True
+            )
+            assert result.returncode == 0
+            assert 'Rochester Public Schools' in result.stdout
+            assert "('Rochester Public Schools'" not in result.stdout
+
     def test_invalid_format_shows_choices(self):
         """Invalid --format should show valid choices."""
         result = subprocess.run(
@@ -194,6 +240,65 @@ data_sources:
             # Message may be in stdout or stderr depending on error type
             output = result.stdout + result.stderr
             assert 'No view' in output or 'views' in output.lower()
+
+
+class TestExplainJsonOutput:
+    """Tests for JSON explain output."""
+
+    def _create_config(self, tmpdir):
+        config_dir = os.path.join(tmpdir, 'config')
+        data_dir = os.path.join(tmpdir, 'data')
+        os.makedirs(config_dir)
+        os.makedirs(data_dir)
+
+        with open(os.path.join(config_dir, 'settings.yaml'), 'w') as f:
+            f.write("""year: 2025
+data_sources:
+  - name: Test
+    file: data/test.csv
+    format: "{date:%Y-%m-%d},{description},{amount}"
+""")
+
+        with open(os.path.join(config_dir, 'merchant_categories.csv'), 'w') as f:
+            f.write("Pattern,Merchant,Category,Subcategory\n")
+            f.write("AMAZON BOOKS,Amazon,Shopping,Books\n")
+            f.write("AMAZON PRIME,Amazon,Subscriptions,Streaming\n")
+            f.write("AMAZE CAFE,Amaze Cafe,Food,Coffee\n")
+
+        with open(os.path.join(data_dir, 'test.csv'), 'w') as f:
+            f.write("date,description,amount\n")
+            f.write("2025-01-15,AMAZON BOOKS ORDER,12.99\n")
+            f.write("2025-01-18,AMAZON PRIME MEMBERSHIP,14.99\n")
+            f.write("2025-01-20,AMAZE CAFE LATTE,6.50\n")
+
+        return config_dir
+
+    @pytest.mark.parametrize(
+        ("query", "match_mode", "matched_names", "merchant_count"),
+        [
+            ("Amazon", "exact", ["Amazon"], 2),
+            ("amazon", "case_insensitive", ["Amazon"], 2),
+            ("Amaz", "partial", ["Amaze Cafe", "Amazon"], 3),
+        ],
+    )
+    def test_explain_json_match_modes_return_single_payload(self, query, match_mode, matched_names, merchant_count):
+        """Exact/case-insensitive/partial explain JSON should be a single parseable payload."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config_dir = self._create_config(tmpdir)
+
+            result = subprocess.run(
+                ['uv', 'run', 'tally', 'explain', '--format', 'json', query, config_dir],
+                capture_output=True,
+                text=True
+            )
+
+            assert result.returncode == 0
+            payload = json.loads(result.stdout)
+            assert payload['query'] == query
+            assert payload['match_mode'] == match_mode
+            assert payload['matched_names'] == matched_names
+            assert len(payload['merchants']) == merchant_count
+            assert [merchant['name'] for merchant in payload['merchants']].count('Amazon') == min(merchant_count, 2)
 
 
 class TestMigration:

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -1,0 +1,86 @@
+import json
+import re
+
+from tally.report import write_summary_file_vue
+
+
+def extract_spending_data(report_path):
+    html = report_path.read_text(encoding='utf-8')
+    match = re.search(r'window\.spendingData = (\{.*?\});', html, re.DOTALL)
+    assert match is not None
+    return json.loads(match.group(1))
+
+
+def merchant_data(name, category, subcategory, amount):
+    return {
+        'name': name,
+        'category': category,
+        'subcategory': subcategory,
+        'transactions': [
+            {
+                'date': '2025-01-15',
+                'month': '2025-01',
+                'description': name,
+                'amount': amount,
+                'source': 'Test',
+                'tags': [],
+            }
+        ],
+        'total': amount,
+        'avg_when_active': amount,
+        'count': 1,
+        'months_active': 1,
+        'is_consistent': True,
+        'tags': set(),
+    }
+
+
+def collect_category_merchants(category_view):
+    merchants = {}
+    for category in category_view.values():
+        for subcategory in category['subcategories'].values():
+            merchants.update(subcategory['merchants'])
+    return merchants
+
+
+def test_report_uses_stable_unambiguous_merchant_ids(tmp_path):
+    first = merchant_data('Acme_A', 'B', 'C', 25)
+    second = merchant_data('Acme', 'A_B', 'C', 40)
+    stats = {
+        'num_months': 1,
+        'by_merchant': {
+            'first': first,
+            'second': second,
+        },
+        'sections': {
+            'Ambiguous IDs': {
+                'merchants': [
+                    ('Acme_A', first),
+                    ('Acme', second),
+                ]
+            }
+        },
+    }
+
+    first_report = tmp_path / 'report-first.html'
+    second_report = tmp_path / 'report-second.html'
+
+    write_summary_file_vue(stats, first_report)
+    write_summary_file_vue(stats, second_report)
+
+    first_data = extract_spending_data(first_report)
+    second_data = extract_spending_data(second_report)
+
+    section_key = 'ambiguous_ids'
+    first_section_merchants = first_data['sections'][section_key]['merchants']
+    second_section_merchants = second_data['sections'][section_key]['merchants']
+
+    assert len(first_section_merchants) == 2
+    assert set(first_section_merchants) == set(second_section_merchants)
+
+    first_category_merchants = collect_category_merchants(first_data['categoryView'])
+    second_category_merchants = collect_category_merchants(second_data['categoryView'])
+
+    assert len(first_category_merchants) == 2
+    assert set(first_category_merchants) == set(second_category_merchants)
+    assert set(first_section_merchants) == set(first_category_merchants)

--- a/tests/test_report_html.py
+++ b/tests/test_report_html.py
@@ -39,6 +39,15 @@ pytestmark = [
 ]
 
 
+def merchant_row(page: Page, merchant_name: str):
+    # Row data-testid now uses composite IDs (name/category/subcategory), so
+    # locating by visible merchant name keeps tests stable across ID format changes.
+    """Locate a merchant row by visible name, independent of internal ID format."""
+    return page.locator("tr.merchant-row").filter(
+        has=page.locator(".merchant-name", has_text=re.compile(rf"^{re.escape(merchant_name)}$"))
+    ).first
+
+
 @pytest.fixture(scope="module")
 def report_path(tmp_path_factory):
     """Generate a test report with known fixture data.
@@ -157,14 +166,14 @@ class TestUINavigation:
     def test_merchants_visible_in_table(self, page: Page, report_path):
         """Merchants are visible in their category tables."""
         page.goto(f"file://{report_path}")
-        expect(page.get_by_test_id("merchant-row-Amazon")).to_be_visible()
-        expect(page.get_by_test_id("merchant-row-Target")).to_be_visible()
+        expect(merchant_row(page, "Amazon")).to_be_visible()
+        expect(merchant_row(page, "Target")).to_be_visible()
 
     def test_merchant_row_expands_on_click(self, page: Page, report_path):
         """Clicking merchant row expands to show transactions."""
         page.goto(f"file://{report_path}")
         # Click on the Amazon row to expand it
-        amazon_row = page.get_by_test_id("merchant-row-Amazon")
+        amazon_row = merchant_row(page, "Amazon")
         amazon_row.click()
         # Should see transaction details
         expect(page.locator("text=AMAZON MARKETPLACE").first).to_be_visible()
@@ -173,7 +182,7 @@ class TestUINavigation:
         """Transactions within a merchant are sorted by date descending (newest first)."""
         page.goto(f"file://{report_path}")
         # Expand Amazon to see transactions
-        amazon_row = page.get_by_test_id("merchant-row-Amazon")
+        amazon_row = merchant_row(page, "Amazon")
         amazon_row.click()
         # Wait for expansion
         page.wait_for_timeout(200)
@@ -269,7 +278,7 @@ class TestCalculationAccuracy:
         """Merchant shows correct transaction count."""
         page.goto(f"file://{report_path}")
         # Amazon has 4 transactions
-        amazon_row = page.get_by_test_id("merchant-row-Amazon")
+        amazon_row = merchant_row(page, "Amazon")
         expect(amazon_row.get_by_test_id("merchant-count")).to_have_text("4")
 
     def test_tag_filter_updates_total(self, page: Page, report_path):
@@ -288,7 +297,7 @@ class TestCalculationAccuracy:
         page.goto(f"file://{report_path}")
 
         # Amazon unfiltered: 4 transactions
-        amazon_row = page.get_by_test_id("merchant-row-Amazon")
+        amazon_row = merchant_row(page, "Amazon")
         expect(amazon_row.get_by_test_id("merchant-count")).to_have_text("4")
 
         # Apply david filter
@@ -305,7 +314,7 @@ class TestCalculationAccuracy:
         page.get_by_test_id("tag-badge").filter(has_text="david").first.click()
 
         # Amazon david total: 45.99 + 199.00 = 244.99 ≈ $245
-        amazon_row = page.get_by_test_id("merchant-row-Amazon")
+        amazon_row = merchant_row(page, "Amazon")
         expect(amazon_row.get_by_test_id("merchant-total")).to_contain_text("$245")
 
     def test_clear_filter_restores_totals(self, page: Page, report_path):
@@ -1054,6 +1063,131 @@ class TestAutocompleteCategories:
         assert len(subcategory_items) == 0
 
 
+@pytest.fixture(scope="module")
+def duplicate_merchant_name_report_path(tmp_path_factory):
+    """Generate a report where one merchant name appears in multiple categories."""
+    tmp_dir = tmp_path_factory.mktemp("duplicate_merchant_name_test")
+    config_dir = tmp_dir / "config"
+    data_dir = tmp_dir / "data"
+    output_dir = tmp_dir / "output"
+
+    config_dir.mkdir()
+    data_dir.mkdir()
+    output_dir.mkdir()
+
+    csv_content = """Date,Description,Amount
+01/05/2025,ROCHESTER PUBLIC SCHOOLS CAFE,42.50
+01/12/2025,ROCHESTER PUBLIC SCHOOLS ACTIVITY FEE,75.00
+01/20/2025,TARGET STORE,30.00
+"""
+    (data_dir / "transactions.csv").write_text(csv_content)
+
+    settings_content = """year: 2025
+
+data_sources:
+  - name: Test
+    file: data/transactions.csv
+    format: "{date},{description},{amount}"
+
+merchants_file: config/merchants.rules
+"""
+    (config_dir / "settings.yaml").write_text(settings_content)
+
+    rules_content = """[RPS Cafeteria]
+match: contains("ROCHESTER PUBLIC SCHOOLS CAFE")
+category: Food
+subcategory: School Meals
+merchant: Rochester Public Schools
+
+[RPS Activity Fee]
+match: contains("ROCHESTER PUBLIC SCHOOLS ACTIVITY")
+category: Education
+subcategory: Fees
+merchant: Rochester Public Schools
+
+[Target]
+match: contains("TARGET")
+category: Shopping
+subcategory: Retail
+"""
+    (config_dir / "merchants.rules").write_text(rules_content)
+
+    report_path = output_dir / "spending.html"
+    subprocess.run(
+        ["uv", "run", "tally", "run", "--format", "html", "-o", str(report_path), str(config_dir)],
+        check=True,
+        capture_output=True
+    )
+
+    return str(report_path)
+
+
+class TestDuplicateMerchantNameFiltering:
+    """Regression tests for merchant filtering with duplicate names across categories."""
+
+    def test_autocomplete_shows_merchant_once_for_duplicate_name(self, page: Page, duplicate_merchant_name_report_path):
+        """Autocomplete should not duplicate merchant entries by category-specific IDs."""
+        page.goto(f"file://{duplicate_merchant_name_report_path}")
+
+        search = page.locator("input[type='text']")
+        search.click()
+        search.fill("Rochester Public Schools")
+        page.wait_for_timeout(100)
+
+        autocomplete = page.locator(".autocomplete-list")
+        merchant_items = autocomplete.locator(
+            ".autocomplete-item:has(.type.merchant)",
+            has_text="Rochester Public Schools"
+        )
+        expect(merchant_items).to_have_count(1)
+
+    def test_merchant_filter_includes_all_category_variants(self, page: Page, duplicate_merchant_name_report_path):
+        """Selecting merchant filter should include same merchant across all categories."""
+        page.goto(f"file://{duplicate_merchant_name_report_path}")
+
+        search = page.locator("input[type='text']")
+        search.click()
+        search.fill("Rochester Public Schools")
+        page.wait_for_timeout(100)
+
+        autocomplete = page.locator(".autocomplete-list")
+        autocomplete.locator(
+            ".autocomplete-item:has(.type.merchant)",
+            has_text="Rochester Public Schools"
+        ).first.click()
+        page.wait_for_timeout(150)
+
+        # Merchant filter should be applied once.
+        merchant_chip = page.get_by_test_id("filter-chips").locator(".filter-chip.merchant")
+        expect(merchant_chip).to_be_visible()
+
+        # Same merchant should remain visible in both category sections.
+        expect(page.get_by_test_id("section-cat-Food").locator(".merchant-row", has_text="Rochester Public Schools")).to_be_visible()
+        expect(page.get_by_test_id("section-cat-Education").locator(".merchant-row", has_text="Rochester Public Schools")).to_be_visible()
+
+        # Unrelated merchants should be filtered out.
+        expect(page.locator(".merchant-row", has_text="Target")).not_to_be_visible()
+
+    def test_clicking_merchant_name_uses_logical_merchant_filter(self, page: Page, duplicate_merchant_name_report_path):
+        """Clicking merchant name should apply merchant-name filter across categories."""
+        page.goto(f"file://{duplicate_merchant_name_report_path}")
+
+        food_rochester_row = page.get_by_test_id("section-cat-Food").locator(".merchant-row", has_text="Rochester Public Schools")
+        food_rochester_row.locator(".merchant-name").click()
+        page.wait_for_timeout(150)
+
+        # Filter chip should indicate merchant filter was applied.
+        merchant_chip = page.get_by_test_id("filter-chips").locator(".filter-chip.merchant")
+        expect(merchant_chip).to_be_visible()
+
+        # Both category buckets for Rochester Public Schools should remain visible.
+        expect(page.get_by_test_id("section-cat-Food").locator(".merchant-row", has_text="Rochester Public Schools")).to_be_visible()
+        expect(page.get_by_test_id("section-cat-Education").locator(".merchant-row", has_text="Rochester Public Schools")).to_be_visible()
+
+        # Unrelated merchant is filtered out.
+        expect(page.locator(".merchant-row", has_text="Target")).not_to_be_visible()
+
+
 # =============================================================================
 # Category 5: Extra Fields Search Tests
 # =============================================================================
@@ -1165,7 +1299,7 @@ class TestExtraFieldsSearch:
         expect(page.get_by_test_id("filter-chip")).to_be_visible()
 
         # Costco merchant should be visible (matches via extra_fields)
-        expect(page.get_by_test_id("merchant-row-Costco")).to_be_visible()
+        expect(merchant_row(page, "Costco")).to_be_visible()
 
     def test_search_auto_expands_merchant(self, page: Page, extra_fields_report_path):
         """Merchant auto-expands when search matches extra_fields."""
@@ -1203,7 +1337,7 @@ class TestExtraFieldsSearch:
         expect(page.get_by_test_id("filter-chip")).to_be_visible()
 
         # Amazon should not be visible (no matching transactions)
-        expect(page.get_by_test_id("merchant-row-Amazon")).not_to_be_visible()
+        expect(merchant_row(page, "Amazon")).not_to_be_visible()
 
     def test_clear_search_shows_all_merchants(self, page: Page, extra_fields_report_path):
         """Clearing search restores all merchants."""
@@ -1219,9 +1353,9 @@ class TestExtraFieldsSearch:
         page.wait_for_timeout(300)
 
         # All merchants should be visible again
-        expect(page.get_by_test_id("merchant-row-Costco")).to_be_visible()
-        expect(page.get_by_test_id("merchant-row-Target")).to_be_visible()
-        expect(page.get_by_test_id("merchant-row-Amazon")).to_be_visible()
+        expect(merchant_row(page, "Costco")).to_be_visible()
+        expect(merchant_row(page, "Target")).to_be_visible()
+        expect(merchant_row(page, "Amazon")).to_be_visible()
 
 
 # =============================================================================
@@ -1631,7 +1765,7 @@ class TestMissingSubcategory:
     """Tests for merchants without subcategories."""
 
     def test_missing_subcategory_shows_other(self, page: Page, report_with_missing_subcategories):
-        """Merchants without subcategory are grouped as 'Other' in subcategory mode."""
+        """Merchants without subcategory are grouped as 'Uncategorized' in subcategory mode."""
         page.goto(f"file://{report_with_missing_subcategories}")
 
         # Switch to subcategory mode
@@ -1639,31 +1773,31 @@ class TestMissingSubcategory:
 
         # Electronics section (Best Buy has no subcategory)
         electronics_section = page.get_by_test_id("section-cat-Electronics")
-        expect(electronics_section.locator(".merchant-name", has_text="Other")).to_be_visible()
+        expect(electronics_section.locator(".merchant-name", has_text="Uncategorized")).to_be_visible()
 
     def test_missing_subcategory_mixed_category(self, page: Page, report_with_missing_subcategories):
-        """Category with mixed subcategories shows both named and 'Other'."""
+        """Category with mixed subcategories shows both named and 'Uncategorized'."""
         page.goto(f"file://{report_with_missing_subcategories}")
 
         # Switch to subcategory mode
         page.locator(".view-toggle button", has_text="Subcategory").click()
 
-        # Retail has Target (Department Store) and Amazon (no subcategory -> Other)
+        # Retail has Target (Department Store) and Amazon (no subcategory -> Uncategorized)
         retail_section = page.get_by_test_id("section-cat-Retail")
         expect(retail_section.locator(".merchant-name", has_text="Department Store")).to_be_visible()
-        expect(retail_section.locator(".merchant-name", has_text="Other")).to_be_visible()
+        expect(retail_section.locator(".merchant-name", has_text="Uncategorized")).to_be_visible()
 
     def test_merchant_mode_shows_empty_subcategory(self, page: Page, report_with_missing_subcategories):
-        """In merchant mode, missing subcategory shows as empty cell."""
+        """In merchant mode, missing subcategory shows as 'Uncategorized'."""
         page.goto(f"file://{report_with_missing_subcategories}")
 
         # Should be in merchant mode by default
         # Best Buy row should have an empty subcategory cell
         electronics_section = page.get_by_test_id("section-cat-Electronics")
         bestbuy_row = electronics_section.locator("tr", has_text="Best Buy")
-        # Second cell (subcategory) should be empty
+        # Second cell (subcategory) should show fallback label
         subcategory_cell = bestbuy_row.locator("td").nth(1)
-        expect(subcategory_cell).to_have_text("")
+        expect(subcategory_cell).to_have_text("Uncategorized")
 
 
 # =============================================================================
@@ -2054,7 +2188,7 @@ class TestTransformDirective:
         page.goto(f"file://{transform_report_path}")
 
         # Wait for Vue to mount and render merchant rows
-        apple_row = page.get_by_test_id("merchant-row-Apple_Purchases")
+        apple_row = merchant_row(page, "Apple Purchases")
         expect(apple_row).to_be_visible()
 
         # Expand Apple Purchases merchant by clicking the chevron
@@ -2069,7 +2203,7 @@ class TestTransformDirective:
         page.goto(f"file://{transform_report_path}")
 
         # Wait for Vue to mount and render merchant rows
-        apple_row = page.get_by_test_id("merchant-row-Apple_Purchases")
+        apple_row = merchant_row(page, "Apple Purchases")
         expect(apple_row).to_be_visible()
 
         # Expand Apple Purchases merchant by clicking the chevron
@@ -2089,7 +2223,7 @@ class TestTransformDirective:
         page.goto(f"file://{transform_report_path}")
 
         # Wait for Vue to mount and render merchant rows
-        apple_row = page.get_by_test_id("merchant-row-Apple_Purchases")
+        apple_row = merchant_row(page, "Apple Purchases")
         expect(apple_row).to_be_visible()
 
         # Expand Apple Purchases merchant by clicking the chevron
@@ -2113,7 +2247,7 @@ class TestTransformDirective:
         page.goto(f"file://{transform_report_path}")
 
         # Wait for Vue to mount and render merchant rows
-        amazon_row = page.get_by_test_id("merchant-row-Amazon")
+        amazon_row = merchant_row(page, "Amazon")
         expect(amazon_row).to_be_visible()
 
         # Expand Amazon merchant by clicking the chevron


### PR DESCRIPTION
Fixes #88 allowing merchants to different categorization rules with same name.

Instead of requiring:
```
[Costco Grocery]
match: contains("COSTCO") and amount <= 200
category: Food
subcategory: Grocery

[Costco Bulk]
match: contains("COSTCO") and amount > 200
category: Shopping
subcategory: Wholesale
```

Can instead be:
```
[Costco]
match: contains("COSTCO") and amount <= 200
category: Food
subcategory: Grocery

[Costco]
match: contains("COSTCO") and amount > 200
category: Shopping
subcategory: Wholesale
```

Allows easier auditing of spending *to a merchant*.  Of course, if you prefer unique merchant names, that is still possible.