### PR TITLE
Add toggle to show/hide negative-total categories in Merchant/Subcategory/View toggles

### DIFF
--- a/src/tally/analyzer.py
+++ b/src/tally/analyzer.py
@@ -13,7 +13,6 @@ from .colors import C
 from .classification import (
     categorize_amount,
     normalize_amount,
-    is_excluded_from_spending,
     calculate_cash_flow,
     calculate_transfers_net,
 )
@@ -225,10 +224,6 @@ def classify_by_sections(by_merchant, sections_config, num_months=12):
     # Convert by_merchant to the format expected by section_engine
     merchant_groups = []
     for merchant_name, data in by_merchant.items():
-        # Skip merchants excluded from spending (income, transfer, investment)
-        # They appear on their respective cards, not in spending sections
-        if is_excluded_from_spending(list(data.get('tags', []))):
-            continue
 
         # Build transactions list for the section filter
         # The 'transactions' key already has the individual transactions

--- a/src/tally/spending_report.css
+++ b/src/tally/spending_report.css
@@ -54,6 +54,7 @@
     --accent-pink-dark: #fa709a;
     --accent-red: #ff6b6b;
     --accent-green: #4ade80;
+    --accent-negative: #663636;
 
     /* Special */
     --bg-amex: #006fcf;
@@ -236,7 +237,7 @@ h1 {
 }
 .date-range-select option {
     background: var(--bg-card);
-    color: var(--text-primary);
+    /* color: var(--text-primary); gray on gray */
     padding: 0.5rem;
 }
 .date-range-select optgroup {
@@ -1441,6 +1442,10 @@ section:nth-child(5) { animation-delay: 0.4s; }
     background: var(--accent-blue);
     border-color: var(--accent-blue);
     color: white;
+}
+.view-toggle button.toggle-negatives.active {
+    background: var(--accent-negative);
+    border-color: var(--accent-negative);
 }
 
 

--- a/src/tally/spending_report.html
+++ b/src/tally/spending_report.html
@@ -176,12 +176,19 @@
                         @click="currentView = 'section'">
                     View
                 </button>
+                <button v-if="currentView === 'category' || hasSections"
+                        class="toggle-negatives"
+                        :class="{ active: includeNegativeTotals }"
+                        :title="includeNegativeTotals ? 'Exclude categories and merchants with net negative totals' : 'Include categories and merchants with net negative totals'"
+                        @click="includeNegativeTotals = !includeNegativeTotals">
+                    {{ includeNegativeTotals ? 'Exclude Negatives' : 'Include Negatives' }}
+                </button>
             </div>
 
             <!-- Section View -->
             <template v-if="currentView === 'section' && hasSections">
                 <merchant-section
-                    v-for="(section, sectionId) in filteredSectionView"
+                    v-for="(section, sectionId) in positiveSectionView"
                     :key="sectionId"
                     :section-key="'sec:' + sectionId"
                     :title="section.title"

--- a/src/tally/spending_report.js
+++ b/src/tally/spending_report.js
@@ -149,8 +149,8 @@ const MerchantSection = defineComponent({
                 </h2>
                 <span class="section-total">
                     <template v-if="categoryMode">
-                        <span class="section-monthly">{{ formatCurrency(totalAmount / numMonths) }}/mo</span> ·
-                        <span class="section-ytd">{{ formatCurrency(totalAmount) }}</span>
+                        <span class="section-monthly" :class="{ 'negative-amount': totalAmount < 0 }">{{ formatCurrency(totalAmount / numMonths) }}/mo</span> ·
+                        <span class="section-ytd" :class="{ 'negative-amount': totalAmount < 0 }">{{ formatCurrency(totalAmount) }}</span>
                         <span class="section-pct" v-if="typeTotals">
                             <span v-if="typeTotals.spending > 0 && totalUnfilteredSpending > 0">({{ formatPct(typeTotals.spending, totalUnfilteredSpending) }})</span>
                             <span v-if="typeTotals.income > 0 && incomeTotal > 0" class="income-pct">({{ formatPct(typeTotals.income, incomeTotal) }} income)</span>
@@ -485,6 +485,7 @@ createApp({
         const currentView = ref('category'); // 'category' or 'section'
         const groupByMode = ref('merchant'); // 'merchant' or 'subcategory'
         const sortConfig = reactive({}); // { 'cat:Food': { column: 'total', dir: 'desc' } }
+        const includeNegativeTotals = ref(false); // show categories with negative filteredTotal
 
         // Chart refs
         const monthlyChart = ref(null);
@@ -660,10 +661,11 @@ createApp({
 
         // Categories to display - show all with non-negative totals
         // Negative totals (credits/refunds) are shown in the Credits section
+        // When includeNegativeTotals is enabled, show all categories regardless of total sign
         const positiveCategoryView = computed(() => {
             const result = {};
             for (const [catName, category] of Object.entries(filteredCategoryView.value)) {
-                if (category.filteredTotal >= 0) {
+                if (includeNegativeTotals.value || category.filteredTotal >= 0) {
                     result[catName] = category;
                 }
             }
@@ -808,7 +810,7 @@ createApp({
         const filteredSectionView = computed(() => {
             const sections = spendingData.value.sections || {};
             const result = {};
-
+			
             for (const [sectionId, section] of Object.entries(sections)) {
                 const filteredMerchants = {};
                 let sectionTotal = 0;
@@ -852,6 +854,18 @@ createApp({
                 section.filteredMerchants = sortMerchantEntries(section.filteredMerchants, cfg.column, cfg.dir);
             }
 
+            return result;
+        });
+
+        // Sections to display - show all with non-negative totals
+        // When includeNegativeTotals is enabled, show all sections regardless of total sign
+        const positiveSectionView = computed(() => {
+            const result = {};
+            for (const [sectionId, section] of Object.entries(filteredSectionView.value)) {
+                if (includeNegativeTotals.value || section.filteredTotal >= 0) {
+                    result[sectionId] = section;
+                }
+            }
             return result;
         });
 
@@ -1987,12 +2001,12 @@ createApp({
             // State
             activeFilters, expandedMerchants, extraFieldMatches, collapsedSections, searchQuery,
             showAutocomplete, autocompleteIndex, isScrolled, isDarkTheme, chartsCollapsed, helpCollapsed,
-            currentView, groupByMode, sortConfig,
+            currentView, groupByMode, sortConfig, includeNegativeTotals,
             // Refs
             monthlyChart, categoryPieChart, categoryByMonthChart,
             // Computed
             spendingData, title, subtitle,
-            visibleSections, filteredCategoryView, positiveCategoryView, subcategoryGroupedView, creditMerchants, filteredSectionView, hasSections,
+            visibleSections, filteredCategoryView, positiveCategoryView, subcategoryGroupedView, creditMerchants, filteredSectionView, positiveSectionView, hasSections,
             sectionTotals, grandTotal, grossSpending, creditsTotal, uncategorizedTotal,
             numFilteredMonths, filteredAutocomplete, availableMonths,
             categoryColorMap, tagColor,

--- a/tests/test_analyzer.py
+++ b/tests/test_analyzer.py
@@ -6,11 +6,12 @@ import tempfile
 import os
 from datetime import date
 
-from tally.analyzer import parse_amount, analyze_transactions, export_json, export_csv
+from tally.analyzer import parse_amount, analyze_transactions, export_json, export_csv, classify_by_sections
 from tally.analyzer import parse_generic_csv as _parse_generic_csv
 from tally.parsers import SkippedRow, ParseResult, _detect_date_format
 from tally.format_parser import parse_format_string
 from tally.merchant_utils import get_all_rules
+from tally.section_engine import parse_sections
 
 
 def parse_generic_csv(*args, **kwargs):
@@ -1589,6 +1590,46 @@ class TestSpecialTags:
         assert stats['income_total'] == 0.0
         assert stats['transfers_in'] == 0.0
         assert stats['transfers_out'] == 0.0
+
+
+class TestSectionViews:
+    """Tests for views.rules section classification behavior."""
+
+    def test_classify_by_sections_includes_transfer_tagged_merchants(self):
+        """Transfer-tagged merchants should still be eligible for section filters."""
+        by_merchant = {
+            'University of Minnesota': {
+                'category': 'College',
+                'subcategory': 'Tuition',
+                'tags': ['transfer'],
+                'transactions': [
+                    {'month': '2025-01', 'amount': 1000.0},
+                ],
+                'total': 1000.0,
+                'monthly_value': 83.33,
+            },
+            'Local Grocery': {
+                'category': 'Food',
+                'subcategory': 'Grocery',
+                'tags': [],
+                'transactions': [
+                    {'month': '2025-01', 'amount': 50.0},
+                ],
+                'total': 50.0,
+                'monthly_value': 4.16,
+            },
+        }
+
+        sections_config = parse_sections("""
+[College Spending]
+filter: category == "College"
+""")
+
+        results = classify_by_sections(by_merchant, sections_config, num_months=12)
+
+        assert 'College Spending' in results
+        assert len(results['College Spending']) == 1
+        assert results['College Spending'][0][0] == 'University of Minnesota'
 
 
 class TestCustomFieldCaptures:


### PR DESCRIPTION
Fixes #89 

Add toggle to show/hide negative-total categories in Merchant/Subcategory/View toggles

- ADDITIONALLY: Month Filter Styling (was gray on gray text)
- Add showNegativeCategories ref (default: false)
- Update positiveCategoryView to pass through all categories when toggle is on
- Add '+'/'-' toggle button adjacent to view mode buttons in HTML (only visible
  in category view), styled with toggle-negatives CSS class using accent-orange
- Style negative total rows red
- Tests for include/exclude toggles for View defs

Default behavior is unchanged: negative-total categories still hidden.
When toggled on, all categories including negative-total ones are visible.
subcategoryGroupedView inherits the fix automatically via positiveCategoryView.