### PR TITLE
Add spending review budgets, anomaly detection, and duplicate warnings

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,19 +5,34 @@ Project-specific guidance for Claude when working on this codebase.
 ## Bash Commands
 
 ```bash
-uv run tally --help              # Show all commands
-uv run tally up /path/to/config  # Run analysis
-uv run tally up --format json -v /path/to/config   # JSON output with reasoning
-uv run tally explain /path/to/config               # Classification summary
-uv run tally explain Netflix /path/to/config       # Explain specific merchant
-uv run tally explain Netflix -vv /path/to/config   # Full details + which rule matched
-uv run tally explain --category Food /path/to/config  # Explain all Food category merchants
-uv run tally explain --tags business /path/to/config  # Explain business-tagged merchants
-uv run tally diag /path/to/config # Debug config issues (shows tag stats)
-uv run tally discover /path/to/config # Find unknown merchants
-uv run tally inspect file.csv    # Analyze CSV structure
-uv run pytest tests/             # Run all tests
-uv run pytest tests/test_analyzer.py -v # Run analyzer tests
+uv run tally --help                                # Show all commands
+uv run tally up --config /path/to/config           # Run analysis
+uv run tally up --config CONFIG --format json -v   # JSON output with reasoning
+uv run tally up --config CONFIG --format summary   # Text summary, no HTML
+uv run tally up --config CONFIG --diff             # Compare against previous run
+uv run tally explain --config CONFIG               # Classification summary
+uv run tally explain Netflix --config CONFIG       # Explain specific merchant
+uv run tally explain Netflix -vv --config CONFIG   # Full details + which rule matched
+uv run tally explain --category Food --config CONFIG  # All Food category merchants
+uv run tally explain --tags business --config CONFIG  # Business-tagged merchants
+uv run tally diag --config CONFIG                  # Debug config (rules, budgets, sources)
+uv run tally discover --config CONFIG              # Find unknown merchants
+uv run tally workflow --config CONFIG              # Context-aware next steps
+uv run tally reference                             # Full rule syntax reference
+uv run tally inspect file.csv                      # Analyze CSV structure
+```
+
+The positional config path (`tally up /path/to/config`) still works but is
+deprecated; prefer `--config`.
+
+**Tests require the dev extra** — plain `uv run pytest` fails with
+"Failed to spawn: pytest":
+
+```bash
+uv run --extra dev pytest tests/                   # Run all tests
+uv run --extra dev pytest tests/test_analyzer.py -v        # Analyzer tests
+uv run --extra dev pytest tests/test_rule_snapshots.py     # Rule engine snapshots
+uv run --extra dev pytest tests/test_report_html.py        # Playwright HTML tests
 ```
 
 ## Example: tally explain Output
@@ -42,33 +57,89 @@ Netflix → Monthly
   Rule: NETFLIX.* (user)   # Shows which pattern matched
 ```
 
-## merchant_categories.csv Format
+## merchants.rules Format
 
-```csv
-Pattern,Merchant,Category,Subcategory,Tags
-NETFLIX,Netflix,Subscriptions,Streaming,entertainment|recurring
-GITHUB,GitHub,Subscriptions,Software,business|recurring
-UBER\s(?!EATS),Uber,Transport,Rideshare,business|reimbursable
-WHOLEFDS,Whole Foods,Food,Grocery,
+Rules live in `config/merchants.rules`. The legacy `merchant_categories.csv`
+format is still read and auto-migrated (`migrations.py`), but `.rules` is the
+current format.
+
+```
+[Netflix]
+match: contains("NETFLIX")
+category: Subscriptions
+subcategory: Streaming
+tags: entertainment, recurring
+
+[Uber Eats]
+match: normalized("UBEREATS")
+category: Food
+subcategory: Delivery
+
+[Costco Bulk]
+match: contains("COSTCO") and amount > 200
+category: Shopping
+subcategory: Wholesale
 ```
 
-**Tags** are optional, pipe-separated labels. Filter with `--tags business` or in UI via `t:business`.
+Match functions: `contains`, `regex`, `normalized`, `anyof`, `startswith`,
+`fuzzy`, plus `amount`/`date`/`month`/`weekday` conditions combined with
+`and`/`or`/`not`. Run `tally reference merchants` for the full syntax.
+
+**Tags** are optional labels. Filter with `--tags business` or in the UI via
+`t:business`. Four tags are special: `income`, `transfer` and `investment`
+are excluded from spending totals, and `refund` shows under Credits.
+
+## Budgets
+
+Optional monthly targets in `settings.yaml`, compared against actuals in every
+output format:
+
+```yaml
+budgets:
+  total: 5000              # all spending, per month
+  Food: 800                # a category
+  Food/Groceries: 500      # a subcategory
+  tag:business: 400        # everything with a tag
+  Travel:                  # an annual pot instead of monthly
+    amount: 6000
+    period: yearly
+```
+
+Only real spending counts (income/transfer/investment are excluded, refunds
+reduce the month they land in). A budget matching nothing is reported with a
+suggested spelling rather than silently showing zero.
 
 ## Core Files
 
-- `src/tally/analyzer.py` - Core analysis, HTML report generation, currency formatting
-- `src/tally/cli.py` - CLI commands, AGENTS.md template (update for new features)
-- `src/tally/config_loader.py` - Settings loading, migration logic
-- `src/tally/format_parser.py` - CSV format string parsing
+- `src/tally/analyzer.py` - Core analysis, terminal summaries, JSON/markdown/CSV export
+- `src/tally/report.py` - HTML report generation, currency formatting
+- `src/tally/cli.py` - Argument parsing only; each command lives in `src/tally/commands/`
+- `src/tally/commands/` - One module per command (`run.py` is `tally up`)
+- `src/tally/config_loader.py` - Settings loading, validation
+- `src/tally/merchant_engine.py` - Rule matching engine
 - `src/tally/merchant_utils.py` - Merchant normalization, rule matching, tags parsing
+- `src/tally/section_engine.py` + `expr_parser.py` - views.rules parsing and evaluation
+- `src/tally/budgets.py` - Budget targets and actual-vs-target evaluation
+- `src/tally/anomalies.py` - Change detection ("worth a look")
+- `src/tally/duplicates.py` - Overlapping-export detection
+- `src/tally/classification.py` - Special tag semantics (income/transfer/investment)
+- `src/tally/templates.py` - Starter files written by `tally init`
+- `src/tally/spending_report.{html,css,js}` - Vue 3 report UI
 - `tests/test_analyzer.py` - Main test file for new features
+- `tests/test_budget_review.py` - Budgets, anomalies, duplicates
+- `tests/test_report_html.py` - Playwright tests for the HTML report
 - `docs/` - Marketing website (GitHub Pages)
 - `config/` - Example configuration files
+
+User-facing features are documented via `tally workflow` and `tally reference`
+(there is no AGENTS.md template in the source; the repo's own `AGENTS.md`
+just points at this file).
 
 ## IMPORTANT: Requirements
 
 **Testing:**
 - YOU MUST add tests for new analyzer features in `tests/test_analyzer.py`
+- YOU MUST use `uv run --extra dev pytest` (plain `uv run pytest` cannot find pytest)
 - YOU MUST use Playwright MCP to verify HTML report changes before committing
 
 **Development:**
@@ -106,7 +177,9 @@ WHOLEFDS,Whole Foods,Food,Grocery,
 - YOU MUST maintain backwards compatibility for `settings.yaml`
 - YOU MUST implement automatic migration in `config_loader.py` if breaking changes are unavoidable
 - YOU MUST document new options in `config/settings.yaml.example`
-- YOU MUST update AGENTS.md in `cli.py` for new user-facing features
+- YOU MUST update `tally workflow` (`src/tally/commands/workflow.py`) and
+  `tally diag` for new user-facing settings, since agents read those to
+  discover features
 
 **Rule Engine (CRITICAL):**
 - The rule engine is the CORE VALUE of tally - users carry personalized rules across versions

--- a/README.md
+++ b/README.md
@@ -26,6 +26,27 @@ tally workflow              # See next steps
 
 Tell your AI assistant: *"Use tally to categorize my transactions"*
 
+## Budgets
+
+Set monthly targets in `config/settings.yaml` and every report compares plan
+against actual:
+
+```yaml
+budgets:
+  total: 5000              # all spending, per month
+  Food: 800                # a category
+  Food/Groceries: 500      # a subcategory
+  tag:business: 400        # everything with a tag
+  Travel:                  # an annual pot instead of monthly
+    amount: 6000
+    period: yearly
+```
+
+`tally up` also flags what changed since previous months - price rises on
+recurring charges, new merchants, recurring bills that did not arrive, and
+category spikes - and warns when two statement exports overlap and would
+otherwise double count.
+
 ## Documentation
 
 Full documentation is available at **[tallyai.money](https://tallyai.money)**:
@@ -46,6 +67,7 @@ Full documentation is available at **[tallyai.money](https://tallyai.money)**:
 | `tally explain` | Explain merchant classifications |
 | `tally inspect` | Analyze CSV structure |
 | `tally reference` | Show full syntax reference |
+| `tally diag` | Diagnose config issues |
 
 ## License
 

--- a/config/settings.yaml.example
+++ b/config/settings.yaml.example
@@ -48,3 +48,43 @@ data_sources:
 # Output settings
 output_dir: output
 html_filename: spending_summary.html
+
+# Merchant rules file - expression-based categorization
+merchants_file: config/merchants.rules
+
+# Views file (optional) - custom spending views
+# views_file: config/views.rules
+
+# ---------------------------------------------------------------------------
+# Budgets (optional)
+# ---------------------------------------------------------------------------
+# Monthly spending targets, compared against actuals in every output format.
+# Keys can be:
+#   total              all spending
+#   <Category>         e.g. Food
+#   <Category>/<Sub>   e.g. Food/Groceries
+#   tag:<name>         e.g. tag:business
+#
+# Only real spending counts. Income, transfers and investment contributions
+# are excluded, and refunds reduce the month they land in.
+#
+# Run 'tally up --format summary' to see the exact category names in your data;
+# a budget that matches nothing is reported with a suggested spelling.
+#
+# budgets:
+#   total: 5000
+#   Food: 800
+#   Food/Groceries: 500
+#   tag:business: 400
+#   Travel:                # an annual pot rather than a monthly one
+#     amount: 6000
+#     period: yearly
+
+# ---------------------------------------------------------------------------
+# Duplicate detection (optional, on by default)
+# ---------------------------------------------------------------------------
+# Warns when the same date, amount and description appear in more than one
+# file. This normally means two statement exports overlap, which would double
+# count that spending. Set to false if the repeats in your data are real.
+#
+# duplicate_check: true

--- a/src/tally/analyzer.py
+++ b/src/tally/analyzer.py
@@ -5,6 +5,7 @@ Analyzes transactions using merchant categorization rules.
 """
 
 import json
+import os
 from collections import defaultdict
 from datetime import datetime
 
@@ -34,6 +35,7 @@ from .report import (
     write_summary_file_vue,
     format_currency,
     format_currency_decimal,
+    format_currency_signed,
     EMBEDDINGS_AVAILABLE,
 )
 
@@ -56,6 +58,15 @@ def analyze_transactions(transactions):
         'transactions': [],  # Individual transactions for drill-down
         'tags': set(),  # Collect all tags from matching rules
         'raw_descriptions': defaultdict(int),  # Track raw description variations
+        # Per-merchant money-flow buckets, using the same rules as the report
+        # totals so merchant-level output always reconciles with the headline
+        # numbers (a transfer with a negative amount is not a refund).
+        'spending': 0.0,
+        'credits': 0.0,
+        'income': 0.0,
+        'investment': 0.0,
+        'transfer_in': 0.0,
+        'transfer_out': 0.0,
     })
     by_month = defaultdict(float)
 
@@ -91,6 +102,12 @@ def analyze_transactions(transactions):
         # Track by merchant
         by_merchant[txn['merchant']]['count'] += 1
         by_merchant[txn['merchant']]['total'] += effective_amount
+        by_merchant[txn['merchant']]['spending'] += cat['spending']
+        by_merchant[txn['merchant']]['credits'] += cat['credits']
+        by_merchant[txn['merchant']]['income'] += cat['income']
+        by_merchant[txn['merchant']]['investment'] += cat['investment']
+        by_merchant[txn['merchant']]['transfer_in'] += cat['transfer_in']
+        by_merchant[txn['merchant']]['transfer_out'] += cat['transfer_out']
         by_merchant[txn['merchant']]['category'] = txn['category']
         by_merchant[txn['merchant']]['subcategory'] = txn['subcategory']
         by_merchant[txn['merchant']]['months'].add(month_key)
@@ -375,7 +392,8 @@ def build_merchant_json(merchant_name, data, verbose=0):
     return result
 
 
-def export_json(stats, verbose=0, category_filter=None, merchant_filter=None):
+def export_json(stats, verbose=0, category_filter=None, merchant_filter=None,
+                budgets=None, anomalies=None, duplicates=None):
     """Export analysis results as JSON with reasoning.
 
     Args:
@@ -383,6 +401,9 @@ def export_json(stats, verbose=0, category_filter=None, merchant_filter=None):
         verbose: Verbosity level (0=basic, 1=trace, 2=full)
         category_filter: Only include merchants in this category
         merchant_filter: Only include these merchants (list of names)
+        budgets: Optional budget report from budgets.build_budget_report()
+        anomalies: Optional report from anomalies.detect_anomalies()
+        duplicates: Optional report from duplicates.build_duplicate_report()
 
     Returns: JSON string
     """
@@ -430,8 +451,9 @@ def export_json(stats, verbose=0, category_filter=None, merchant_filter=None):
             if data['total'] > 0
         ],
         'credits': [
-            {'merchant': name, 'category': data.get('category', ''), 'amount': round(abs(data['total']), 2)}
-            for name, data in by_merchant.items() if data['total'] < 0
+            {'merchant': name, 'category': data.get('category', ''), 'amount': round(data['credits'], 2)}
+            for name, data in sorted(by_merchant.items(), key=lambda x: x[1].get('credits', 0), reverse=True)
+            if data.get('credits', 0) > 0
         ],
         'merchants': []
     }
@@ -450,10 +472,23 @@ def export_json(stats, verbose=0, category_filter=None, merchant_filter=None):
     merchants.sort(key=lambda x: x['monthly_value'], reverse=True)
     output['merchants'] = merchants
 
+    # Review data. Only emitted when present so existing consumers of the JSON
+    # (including the run-over-run diff) see no change unless the feature is used.
+    if budgets and budgets.get('enabled'):
+        from .budgets import budget_report_to_dict
+        output['budgets'] = budget_report_to_dict(budgets)
+    if anomalies and anomalies.get('enabled'):
+        from .anomalies import anomaly_report_to_dict
+        output['anomalies'] = anomaly_report_to_dict(anomalies)
+    if duplicates and duplicates.get('enabled') and duplicates.get('total_count'):
+        from .duplicates import duplicate_report_to_dict
+        output['duplicates'] = duplicate_report_to_dict(duplicates)
+
     return json.dumps(output, indent=2)
 
 
-def export_markdown(stats, verbose=0, category_filter=None, merchant_filter=None, currency_format="${amount}"):
+def export_markdown(stats, verbose=0, category_filter=None, merchant_filter=None,
+                    currency_format="${amount}", budgets=None, anomalies=None, duplicates=None):
     """Export analysis results as Markdown with reasoning.
 
     Args:
@@ -462,6 +497,9 @@ def export_markdown(stats, verbose=0, category_filter=None, merchant_filter=None
         category_filter: Only include merchants in this category
         merchant_filter: Only include these merchants (list of names)
         currency_format: Format string for currency (e.g. "${amount}" or "£{amount}")
+        budgets: Optional budget report from budgets.build_budget_report()
+        anomalies: Optional report from anomalies.detect_anomalies()
+        duplicates: Optional report from duplicates.build_duplicate_report()
 
     Returns: Markdown string
     """
@@ -490,6 +528,46 @@ def export_markdown(stats, verbose=0, category_filter=None, merchant_filter=None
     transfers_net = stats.get('transfers_net', 0)
 
     lines = ['# Financial Report\n']
+
+    # Budgets lead the report: during a review the targets matter more than
+    # the raw totals underneath them.
+    if budgets and budgets.get('enabled') and budgets.get('results'):
+        lines.append('## Budgets\n')
+        lines.append('| Target | Period | Budget | Actual | Used | Variance | Status |')
+        lines.append('|--------|--------|--------|--------|------|----------|--------|')
+        for result in budgets['results']:
+            lines.append(
+                f"| {result.label} | {result.period} | {fmt(result.target)} | "
+                f"{fmt(result.comparison_actual)} | {result.pct_used:.0f}% | "
+                f"{fmt(result.variance, show_sign=True)} | {result.status} |"
+            )
+        lines.append('')
+        for problem in budgets.get('problems', []):
+            suggestions = ', '.join(problem['suggestions']) or 'none found'
+            lines.append(f"> Budget `{problem['key']}` matched no transactions. Did you mean: {suggestions}")
+        if budgets.get('problems'):
+            lines.append('')
+
+    # Anomalies
+    if anomalies and anomalies.get('enabled') and anomalies.get('anomalies'):
+        lines.append(f"## Worth a Look ({anomalies.get('latest_month', '')})\n")
+        for anomaly in anomalies['anomalies']:
+            marker = '**!**' if anomaly.severity == 'warn' else '-'
+            lines.append(f"{marker} **{anomaly.title}** - {anomaly.detail}")
+        lines.append('')
+
+    # Duplicate warning
+    if duplicates and duplicates.get('enabled') and duplicates.get('cross_file'):
+        cross = duplicates['cross_file']
+        lines.append('## Possible Duplicates\n')
+        lines.append(f"{len(cross)} transaction(s) appear in more than one file, "
+                     f"double counting {fmt(duplicates.get('cross_file_impact', 0))}.\n")
+        lines.append('| Date | Amount | Description | Files |')
+        lines.append('|------|--------|-------------|-------|')
+        for group in cross[:20]:
+            files = ', '.join(os.path.basename(f) for f in group.files)
+            lines.append(f"| {group.date} | {fmt(group.amount)} | {group.description} | {files} |")
+        lines.append('')
 
     # Cash Flow Summary
     lines.append('## Cash Flow\n')
@@ -520,14 +598,14 @@ def export_markdown(stats, verbose=0, category_filter=None, merchant_filter=None
             lines.append(f"| {month} | {fmt(total)} |")
         lines.append('')
 
-    # Credits/Refunds
-    credit_merchants = [(m, d) for m, d in by_merchant.items() if d['total'] < 0]
+    # Credits/Refunds (genuine refunds only - transfers/income have their own rows)
+    credit_merchants = [(m, d) for m, d in by_merchant.items() if d.get('credits', 0) > 0]
     if credit_merchants:
         lines.append('## Credits/Refunds\n')
         lines.append('| Merchant | Category | Amount |')
         lines.append('|----------|----------|--------|')
-        for name, data in sorted(credit_merchants, key=lambda x: x[1]['total']):
-            lines.append(f"| {name} | {data.get('category', '')} | {fmt(data['total'], show_sign=True)} |")
+        for name, data in sorted(credit_merchants, key=lambda x: x[1]['credits'], reverse=True):
+            lines.append(f"| {name} | {data.get('category', '')} | {fmt(data['credits'], show_sign=True)} |")
         lines.append(f"| **Total** | | **{fmt(credits_total, show_sign=True)}** |")
         lines.append('')
 
@@ -720,18 +798,21 @@ def print_summary(stats, title=None, filter_category=None, currency_format="${am
     print(f"\nMerchants:                   {len(by_merchant):>14}")
 
     # =========================================================================
-    # CREDITS/REFUNDS (if any negative totals)
+    # CREDITS/REFUNDS
     # =========================================================================
-    credit_merchants = [(m, d) for m, d in by_merchant.items() if d['total'] < 0]
+    # Only genuine refunds count here. A negative merchant total can also come
+    # from transfers or income (e.g. a stock sale), which are reported in their
+    # own sections - including them here made the rows disagree with the total.
+    credit_merchants = [(m, d) for m, d in by_merchant.items() if d.get('credits', 0) > 0]
     if credit_merchants:
         print("\n" + "=" * 80)
         print("CREDITS/REFUNDS")
         print("=" * 80)
         print(f"\n{'Merchant':<30} {'Category':<20} {'Amount':>14}")
         print("-" * 68)
-        for merchant, data in sorted(credit_merchants, key=lambda x: x[1]['total']):
+        for merchant, data in sorted(credit_merchants, key=lambda x: x[1]['credits'], reverse=True):
             category = data.get('category', 'Unknown')[:20]
-            print(f"{merchant:<30} {category:<20} +{fmt(abs(data['total'])):>14}")
+            print(f"{merchant:<30} {category:<20} +{fmt(data['credits']):>14}")
         print(f"\n{'TOTAL CREDITS':<30} {'':<20} +{fmt(credits_total):>14}")
 
     # =========================================================================
@@ -942,6 +1023,182 @@ def print_sections_summary(stats, title=None, currency_format="${amount}", only_
         print()
         print(f"  {C.DIM}Investments:{C.RESET} {C.CYAN}{fmt(investment_total)}{C.RESET} {C.DIM}(401K, IRA, etc.){C.RESET}")
     print("=" * 80)
+
+
+# =============================================================================
+# REVIEW OUTPUT - Budgets, anomalies and duplicate warnings
+# =============================================================================
+
+# Width of the inline progress bar drawn next to each budget.
+BUDGET_BAR_WIDTH = 14
+
+
+def _budget_bar(pct_used):
+    """Render a progress bar for a budget, capped at 100% of the bar width."""
+    filled = int(min(pct_used, 100) / 100 * BUDGET_BAR_WIDTH)
+    return '█' * filled + '░' * (BUDGET_BAR_WIDTH - filled)
+
+
+def _budget_color(status):
+    return {'over': C.RED, 'near': C.YELLOW}.get(status, C.GREEN)
+
+
+def print_budget_summary(budget_report, currency_format="${amount}", latest_month_complete=True):
+    """Print budget targets versus actual spending.
+
+    Args:
+        budget_report: Report from budgets.build_budget_report()
+        currency_format: Format string for currency
+        latest_month_complete: False when the newest month is only partially
+            covered by the data, which makes actuals look artificially low.
+    """
+    if not budget_report or not budget_report.get('enabled'):
+        return
+
+    results = budget_report.get('results', [])
+    if not results:
+        return
+
+    def fmt(amount):
+        return format_currency_decimal(amount, currency_format)
+
+    def fmt_signed(amount):
+        return format_currency_signed(amount, currency_format)
+
+    print("\n" + "=" * 80)
+    print("BUDGETS")
+    print("=" * 80)
+    print()
+
+    over = [r for r in results if r.status == 'over']
+    near = [r for r in results if r.status == 'near']
+    if over:
+        print(f"  {C.RED}{len(over)} of {len(results)} targets over budget{C.RESET}")
+    elif near:
+        print(f"  {C.YELLOW}{len(near)} of {len(results)} targets close to the limit{C.RESET}")
+    else:
+        print(f"  {C.GREEN}All {len(results)} targets within budget{C.RESET}")
+    print()
+
+    print(f"{'Target':<24} {'Budget':>11} {'Actual':>11}  {'Progress':<{BUDGET_BAR_WIDTH}} {'':>6} {'Variance':>12}")
+    print("-" * 80)
+
+    for result in results:
+        color = _budget_color(result.status)
+        period_note = '/yr' if result.period == 'yearly' else '/mo'
+        label = result.label[:23]
+        variance = f"{fmt_signed(result.variance)}{'/yr' if result.period == 'yearly' else '/mo'}"
+        print(
+            f"{label:<24} {fmt(result.target):>11} {fmt(result.comparison_actual):>11}  "
+            f"{color}{_budget_bar(result.pct_used)}{C.RESET} {color}{result.pct_used:>5.0f}%{C.RESET} "
+            f"{color}{variance:>15}{C.RESET}"
+        )
+
+        if result.months_over:
+            print(f"    {C.DIM}↳ over target in {result.months_over} of "
+                  f"{result.num_months} months{C.RESET}")
+
+    if not latest_month_complete:
+        print()
+        print(f"  {C.DIM}Note: the most recent month is partial, so actuals for it "
+              f"are lower than a full month.{C.RESET}")
+
+    # A budget that matches nothing silently reads as perfect discipline, so
+    # always call it out with something concrete to fix.
+    for problem in budget_report.get('problems', []):
+        print()
+        print(f"  {C.YELLOW}⚠{C.RESET} Budget '{problem['key']}' did not match any transactions.")
+        if problem['suggestions']:
+            print(f"    Did you mean: {', '.join(problem['suggestions'])}")
+        else:
+            print(f"    No {problem['scope']} values were found in your data.")
+        print(f"    Check the name against 'tally up --format summary' or 'tally explain'.")
+
+
+def print_anomaly_summary(anomaly_report, currency_format="${amount}"):
+    """Print the 'worth a look' list of changes since previous months."""
+    if not anomaly_report or not anomaly_report.get('enabled'):
+        return
+
+    anomalies = anomaly_report.get('anomalies', [])
+    if not anomalies:
+        return
+
+    latest_month = anomaly_report.get('latest_month', '')
+    print("\n" + "=" * 80)
+    print(f"WORTH A LOOK ({latest_month})")
+    print("=" * 80)
+    print()
+
+    for anomaly in anomalies:
+        if anomaly.severity == 'warn':
+            marker = f"{C.YELLOW}⚠{C.RESET}"
+        else:
+            marker = f"{C.DIM}·{C.RESET}"
+        print(f"  {marker} {C.BOLD}{anomaly.title}{C.RESET}")
+        print(f"    {C.DIM}{anomaly.detail}{C.RESET}")
+
+    total_found = anomaly_report.get('total_found', len(anomalies))
+    if total_found > len(anomalies):
+        print()
+        print(f"  {C.DIM}... and {total_found - len(anomalies)} more{C.RESET}")
+
+    if not anomaly_report.get('latest_month_complete', True):
+        print()
+        print(f"  {C.DIM}Note: {latest_month} is partial, so month-over-month "
+              f"comparisons will understate it.{C.RESET}")
+
+
+def print_duplicate_warning(duplicate_report, currency_format="${amount}", verbose=0):
+    """Warn about transactions that appear more than once.
+
+    Cross-file duplicates are shown by default because they almost always mean
+    two exports overlap and the totals are inflated. Repeats within a single
+    file are usually legitimate, so they need -v.
+    """
+    if not duplicate_report or not duplicate_report.get('enabled'):
+        return
+
+    def fmt(amount):
+        return format_currency_decimal(amount, currency_format)
+
+    def fmt_signed(amount):
+        return format_currency_signed(amount, currency_format)
+
+    cross = duplicate_report.get('cross_file', [])
+    same = duplicate_report.get('same_file', [])
+
+    if cross:
+        impact = duplicate_report.get('cross_file_impact', 0)
+        print()
+        print(f"{C.YELLOW}⚠ {len(cross)} transaction(s) appear in more than one file "
+              f"({fmt(impact)} counted twice){C.RESET}")
+
+        shown = cross if verbose >= 1 else cross[:3]
+        for group in shown:
+            files = ', '.join(os.path.basename(f) for f in group.files)
+            print(f"    {group.date}  {fmt_signed(group.amount):>12}  {group.description[:34]:<34} {C.DIM}{files}{C.RESET}")
+        if len(cross) > len(shown):
+            print(f"    {C.DIM}... and {len(cross) - len(shown)} more{C.RESET}")
+
+        print(f"  {C.DIM}Your totals include these twice. Remove the overlapping export, "
+              f"narrow the glob in settings.yaml,{C.RESET}")
+        print(f"  {C.DIM}or set 'duplicate_check: off' if the repeats are real.{C.RESET}")
+
+    if same and verbose >= 1:
+        impact = duplicate_report.get('same_file_impact', 0)
+        print()
+        print(f"{C.DIM}{len(same)} repeated transaction(s) within a single file "
+              f"({fmt(impact)}). These are often legitimate.{C.RESET}")
+        for group in same[:10]:
+            print(f"    {group.date}  {fmt_signed(group.amount):>12}  {group.description[:34]:<34} "
+                  f"{C.DIM}x{group.count}{C.RESET}")
+        if len(same) > 10:
+            print(f"    {C.DIM}... and {len(same) - 10} more{C.RESET}")
+    elif same:
+        print()
+        print(f"{C.DIM}{len(same)} repeated transaction(s) within a single file. "
+              f"Run with -v to list them.{C.RESET}")
 
 
 # =============================================================================

--- a/src/tally/anomalies.py
+++ b/src/tally/anomalies.py
@@ -1,0 +1,407 @@
+"""
+Anomaly detection - the "worth a look" list for a spending review.
+
+Reviewing a report line by line is slow, and the interesting things are usually
+changes rather than levels. This module surfaces the handful of merchants and
+categories that changed behaviour, so a review can start with them:
+
+    new_merchant       something started charging you this month
+    price_increase     a recurring charge went up
+    missing_recurring  a regular charge did not arrive (cancelled, or missed)
+    category_spike     a category cost far more this month than it usually does
+    large_transaction  a single charge far larger than that merchant's norm
+
+Everything is measured against the merchant's own history rather than a global
+threshold, so a $12 subscription doubling is reported while a $12 swing in
+groceries is not.
+
+The most recent month in a export is often partial. Detectors that depend on a
+complete month are suppressed in that case, because "your rent is missing" on
+the 3rd of the month is noise, not a finding.
+"""
+
+import calendar
+from dataclasses import dataclass, field
+from statistics import median
+from typing import Any, Dict, List
+
+from .classification import categorize_amount
+
+# Detector kinds
+NEW_MERCHANT = 'new_merchant'
+PRICE_INCREASE = 'price_increase'
+MISSING_RECURRING = 'missing_recurring'
+CATEGORY_SPIKE = 'category_spike'
+LARGE_TRANSACTION = 'large_transaction'
+
+SEVERITY_WARN = 'warn'
+SEVERITY_INFO = 'info'
+
+# Thresholds. These are deliberately blunt: the goal is a short list a human
+# actually reads, not exhaustive statistical coverage.
+MIN_MONTHS_FOR_RECURRING = 3       # history needed before "usual" means anything
+PRICE_INCREASE_PCT = 0.20          # +20% on a recurring charge
+PRICE_INCREASE_MIN_ABS = 5.0       # ...and at least this many currency units
+NEW_MERCHANT_MIN_TOTAL = 25.0      # ignore trivial first-time charges
+CATEGORY_SPIKE_RATIO = 1.5         # 50% above the trailing average
+CATEGORY_SPIKE_MIN_ABS = 100.0
+LARGE_TXN_RATIO = 3.0              # 3x the merchant's median charge
+LARGE_TXN_MIN_ABS = 100.0
+MISSING_GRACE_DAYS = 3             # wait this long past the usual charge day
+# "Missing" is only meaningful for charges that really do arrive every month.
+# Requiring both dense history and a charge last month keeps seasonal or
+# occasional merchants (a warehouse run every other month) off the list.
+MISSING_MIN_COVERAGE = 0.6
+
+# A month is treated as complete once data runs to at least this day.
+MONTH_COMPLETE_DAY = 28
+
+
+@dataclass
+class Anomaly:
+    """One thing worth looking at."""
+    kind: str
+    severity: str
+    title: str
+    detail: str
+    subject: str = ''
+    category: str = ''
+    month: str = ''
+    amount: float = 0.0
+    impact: float = 0.0
+    context: Dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            'kind': self.kind,
+            'severity': self.severity,
+            'title': self.title,
+            'detail': self.detail,
+            'subject': self.subject,
+            'category': self.category,
+            'month': self.month,
+            'amount': round(self.amount, 2),
+            'impact': round(self.impact, 2),
+            'context': self.context,
+        }
+
+
+def _default_fmt(amount: float) -> str:
+    """Fallback money formatter used when the caller does not supply one."""
+    return f"{amount:,.2f}"
+
+
+def _spend(txn) -> float:
+    """Net spending contribution of a transaction (refunds are negative)."""
+    bucket = categorize_amount(txn.get('amount', 0), txn.get('tags', []))
+    return bucket['spending'] - bucket['credits']
+
+
+def _day_of_month(txn) -> int:
+    """Day component of a transaction's ``MM/DD`` date, 0 when unavailable."""
+    raw = txn.get('date', '')
+    parts = str(raw).split('/')
+    if len(parts) >= 2 and parts[1].isdigit():
+        return int(parts[1])
+    return 0
+
+
+def _merchant_monthly_spend(data) -> Dict[str, float]:
+    by_month: Dict[str, float] = {}
+    for txn in data.get('transactions', []):
+        net = _spend(txn)
+        if net:
+            month = txn.get('month', '')
+            by_month[month] = by_month.get(month, 0.0) + net
+    return by_month
+
+
+def _latest_month_day(by_merchant) -> int:
+    """Highest day-of-month seen in the most recent month of data."""
+    latest_month = ''
+    latest_day = 0
+    for data in by_merchant.values():
+        for txn in data.get('transactions', []):
+            month = txn.get('month', '')
+            if month > latest_month:
+                latest_month, latest_day = month, _day_of_month(txn)
+            elif month == latest_month:
+                latest_day = max(latest_day, _day_of_month(txn))
+    return latest_day
+
+
+def detect_new_merchants(by_merchant, latest_month, fmt=_default_fmt) -> List[Anomaly]:
+    """Merchants whose very first charge landed in the most recent month."""
+    found = []
+    for name, data in by_merchant.items():
+        spend_by_month = _merchant_monthly_spend(data)
+        if not spend_by_month or min(spend_by_month) != latest_month:
+            continue
+        total = spend_by_month[latest_month]
+        if total < NEW_MERCHANT_MIN_TOTAL:
+            continue
+        found.append(Anomaly(
+            kind=NEW_MERCHANT,
+            severity=SEVERITY_INFO,
+            title=f"{name} is new",
+            detail=f"First charge in {latest_month}, {fmt(total)} across "
+                   f"{data.get('count', 1)} transaction(s).",
+            subject=name,
+            category=data.get('category', ''),
+            month=latest_month,
+            amount=total,
+            impact=total,
+        ))
+    return found
+
+
+def detect_price_increases(by_merchant, latest_month, fmt=_default_fmt) -> List[Anomaly]:
+    """Recurring charges that went up compared to their own history."""
+    found = []
+    for name, data in by_merchant.items():
+        spend_by_month = _merchant_monthly_spend(data)
+        if len(spend_by_month) < MIN_MONTHS_FOR_RECURRING:
+            continue
+        if latest_month not in spend_by_month:
+            continue
+
+        prior = [amount for month, amount in spend_by_month.items() if month != latest_month]
+        if not prior:
+            continue
+
+        baseline = median(prior)
+        current = spend_by_month[latest_month]
+        if baseline <= 0:
+            continue
+
+        delta = current - baseline
+        if delta < PRICE_INCREASE_MIN_ABS or delta / baseline < PRICE_INCREASE_PCT:
+            continue
+
+        pct = delta / baseline * 100
+        found.append(Anomaly(
+            kind=PRICE_INCREASE,
+            severity=SEVERITY_WARN,
+            title=f"{name} went up {pct:.0f}%",
+            detail=f"{latest_month} was {fmt(current)} versus a usual {fmt(baseline)}.",
+            subject=name,
+            category=data.get('category', ''),
+            month=latest_month,
+            amount=current,
+            impact=delta,
+            context={'baseline': round(baseline, 2), 'current': round(current, 2),
+                     'pct_change': round(pct, 1)},
+        ))
+    return found
+
+
+def _months_between(start_month: str, end_month: str) -> int:
+    """Inclusive count of YYYY-MM months from start to end."""
+    try:
+        start_year, start_mon = (int(p) for p in start_month.split('-'))
+        end_year, end_mon = (int(p) for p in end_month.split('-'))
+    except (ValueError, AttributeError):
+        return 0
+    return (end_year - start_year) * 12 + (end_mon - start_mon) + 1
+
+
+def _days_in_month(month: str) -> int:
+    """Number of days in a YYYY-MM month, defaulting to 31 if unparseable."""
+    try:
+        year, mon = (int(p) for p in month.split('-'))
+        return calendar.monthrange(year, mon)[1]
+    except (ValueError, AttributeError, IndexError):
+        return 31
+
+
+def _previous_month(month: str) -> str:
+    """The YYYY-MM month immediately before ``month``."""
+    try:
+        year, mon = (int(p) for p in month.split('-'))
+    except (ValueError, AttributeError):
+        return ''
+    if mon == 1:
+        return f"{year - 1:04d}-12"
+    return f"{year:04d}-{mon - 1:02d}"
+
+
+def detect_missing_recurring(by_merchant, latest_month, latest_day, month_complete=False,
+                             fmt=_default_fmt) -> List[Anomaly]:
+    """Regular charges that did not show up in the most recent month.
+
+    ``month_complete`` is accepted for symmetry with the other detectors but is
+    not used as a gate: whether a charge is overdue depends on that merchant's
+    own billing day, not on whether the month as a whole looks finished.
+    """
+    previous_month = _previous_month(latest_month)
+    found = []
+    for name, data in by_merchant.items():
+        spend_by_month = _merchant_monthly_spend(data)
+        if len(spend_by_month) < MIN_MONTHS_FOR_RECURRING:
+            continue
+        if latest_month in spend_by_month:
+            continue
+
+        months = sorted(spend_by_month)
+        # Only care about charges that were still running right up to the gap.
+        if months[-1] >= latest_month:
+            continue
+        if months[-1] != previous_month:
+            continue
+
+        # How consistently has it charged since it first appeared?
+        expected = _months_between(months[0], latest_month)
+        if expected and len(spend_by_month) / expected < MISSING_MIN_COVERAGE:
+            continue
+
+        days = [d for d in (_day_of_month(t) for t in data.get('transactions', [])) if d]
+        usual_day = median(days) if days else 1
+
+        # If the charge normally lands later in the month than our data runs,
+        # it is not missing - the export simply stops before it would appear.
+        # The threshold is clamped to the length of the month so a merchant
+        # that bills on the 31st is not suppressed forever in shorter months.
+        due_by = min(usual_day + MISSING_GRACE_DAYS, _days_in_month(latest_month))
+        if latest_day < due_by:
+            continue
+
+        baseline = median(list(spend_by_month.values()))
+        found.append(Anomaly(
+            kind=MISSING_RECURRING,
+            severity=SEVERITY_WARN,
+            title=f"{name} did not charge in {latest_month}",
+            detail=f"Charged in {len(spend_by_month)} earlier month(s), usually around "
+                   f"{fmt(baseline)} on day {int(usual_day)}. Cancelled, or a missed bill?",
+            subject=name,
+            category=data.get('category', ''),
+            month=latest_month,
+            amount=0.0,
+            impact=baseline,
+            context={'baseline': round(baseline, 2), 'last_seen': months[-1],
+                     'usual_day': int(usual_day)},
+        ))
+    return found
+
+
+def detect_category_spikes(by_merchant, latest_month, fmt=_default_fmt) -> List[Anomaly]:
+    """Categories that cost far more in the latest month than they usually do."""
+    by_category: Dict[str, Dict[str, float]] = {}
+    for data in by_merchant.values():
+        category = data.get('category', '') or 'Uncategorized'
+        target = by_category.setdefault(category, {})
+        for month, amount in _merchant_monthly_spend(data).items():
+            target[month] = target.get(month, 0.0) + amount
+
+    found = []
+    for category, spend_by_month in by_category.items():
+        if len(spend_by_month) < MIN_MONTHS_FOR_RECURRING or latest_month not in spend_by_month:
+            continue
+
+        prior = [amount for month, amount in spend_by_month.items() if month != latest_month]
+        if not prior:
+            continue
+
+        baseline = sum(prior) / len(prior)
+        current = spend_by_month[latest_month]
+        delta = current - baseline
+        if baseline <= 0 or delta < CATEGORY_SPIKE_MIN_ABS or current / baseline < CATEGORY_SPIKE_RATIO:
+            continue
+
+        found.append(Anomaly(
+            kind=CATEGORY_SPIKE,
+            severity=SEVERITY_WARN,
+            title=f"{category} spiked in {latest_month}",
+            detail=f"{fmt(current)} against a usual {fmt(baseline)} per month "
+                   f"({fmt(delta)} more than normal).",
+            subject=category,
+            category=category,
+            month=latest_month,
+            amount=current,
+            impact=delta,
+            context={'baseline': round(baseline, 2), 'current': round(current, 2)},
+        ))
+    return found
+
+
+def detect_large_transactions(by_merchant, fmt=_default_fmt) -> List[Anomaly]:
+    """Single charges far above what that merchant normally costs."""
+    found = []
+    for name, data in by_merchant.items():
+        spends = [(txn, _spend(txn)) for txn in data.get('transactions', [])]
+        amounts = [amount for _, amount in spends if amount > 0]
+        if len(amounts) < MIN_MONTHS_FOR_RECURRING:
+            continue
+
+        baseline = median(amounts)
+        if baseline <= 0:
+            continue
+
+        txn, largest = max(spends, key=lambda pair: pair[1])
+        if largest < LARGE_TXN_MIN_ABS or largest / baseline < LARGE_TXN_RATIO:
+            continue
+
+        found.append(Anomaly(
+            kind=LARGE_TRANSACTION,
+            severity=SEVERITY_INFO,
+            title=f"Unusually large {name} charge",
+            detail=f"{fmt(largest)} on {txn.get('date', '')} versus a typical {fmt(baseline)}.",
+            subject=name,
+            category=data.get('category', ''),
+            month=txn.get('month', ''),
+            amount=largest,
+            impact=largest - baseline,
+            context={'baseline': round(baseline, 2), 'date': txn.get('date', '')},
+        ))
+    return found
+
+
+def detect_anomalies(stats, limit: int = 12, fmt=None) -> Dict[str, Any]:
+    """Run every detector and return the most significant findings.
+
+    Args:
+        stats: Analysis results from ``analyze_transactions``.
+        limit: Maximum number of anomalies to return.
+        fmt: Optional money formatter used to build human-readable detail text.
+    """
+    fmt = fmt or _default_fmt
+    by_merchant = stats.get('by_merchant', {})
+    months = sorted(stats.get('by_month', {}).keys())
+
+    # Comparing "this month" to history needs at least some history.
+    if len(months) < 2:
+        return {'enabled': False, 'anomalies': [], 'latest_month': months[-1] if months else '',
+                'latest_month_complete': True, 'reason': 'not_enough_history'}
+
+    latest_month = months[-1]
+    latest_day = _latest_month_day(by_merchant)
+    month_complete = latest_day >= MONTH_COMPLETE_DAY
+
+    found = []
+    found += detect_new_merchants(by_merchant, latest_month, fmt)
+    found += detect_price_increases(by_merchant, latest_month, fmt)
+    found += detect_missing_recurring(by_merchant, latest_month, latest_day, month_complete, fmt)
+    found += detect_category_spikes(by_merchant, latest_month, fmt)
+    found += detect_large_transactions(by_merchant, fmt)
+
+    # Warnings first, then by how much money the finding represents.
+    found.sort(key=lambda a: (a.severity != SEVERITY_WARN, -a.impact))
+
+    return {
+        'enabled': True,
+        'anomalies': found[:limit],
+        'total_found': len(found),
+        'latest_month': latest_month,
+        'latest_month_complete': month_complete,
+        'latest_day': latest_day,
+    }
+
+
+def anomaly_report_to_dict(report: Dict[str, Any]) -> Dict[str, Any]:
+    """Convert an anomaly report to plain JSON-serializable data."""
+    return {
+        'enabled': report.get('enabled', False),
+        'latest_month': report.get('latest_month', ''),
+        'latest_month_complete': report.get('latest_month_complete', True),
+        'total_found': report.get('total_found', 0),
+        'items': [a.to_dict() for a in report.get('anomalies', [])],
+    }

--- a/src/tally/budgets.py
+++ b/src/tally/budgets.py
@@ -88,6 +88,11 @@ class BudgetResult:
     actual_by_month: Dict[str, float] = field(default_factory=dict)
     num_months: int = 0
     matched_merchants: int = 0
+    # The latest month when it is only partially covered by the data. It is
+    # kept in ``actual_by_month`` and ``actual_total`` for display, but excluded
+    # from the monthly average so a mid-month review is not flattered by the few
+    # days of spend that have landed so far.
+    excluded_month: str = ''
 
     @property
     def key(self) -> str:
@@ -115,7 +120,27 @@ class BudgetResult:
 
     @property
     def actual_monthly_avg(self) -> float:
-        return self.actual_total / self.num_months if self.num_months else 0.0
+        months = self._avg_month_count
+        return self._avg_total / months if months else 0.0
+
+    @property
+    def _avg_month_count(self) -> int:
+        """Months the monthly average is spread over.
+
+        A partial latest month is dropped so it does not drag the average down,
+        unless it is the only month we have (in which case a partial figure is
+        better than nothing).
+        """
+        if self.excluded_month and self.num_months > 1:
+            return self.num_months - 1
+        return self.num_months
+
+    @property
+    def _avg_total(self) -> float:
+        """Spend the monthly average is computed from (partial month removed)."""
+        if self.excluded_month and self.num_months > 1:
+            return self.actual_total - self.actual_by_month.get(self.excluded_month, 0.0)
+        return self.actual_total
 
     @property
     def comparison_actual(self) -> float:
@@ -292,14 +317,20 @@ def _merchant_spend_by_month(data) -> Dict[str, float]:
     return by_month
 
 
-def evaluate_budgets(budgets: List[Budget], stats) -> List[BudgetResult]:
-    """Evaluate parsed budgets against analysis results."""
+def evaluate_budgets(budgets: List[Budget], stats, latest_month_complete: bool = True) -> List[BudgetResult]:
+    """Evaluate parsed budgets against analysis results.
+
+    When ``latest_month_complete`` is False the most recent month is treated as
+    partial and excluded from each budget's monthly average, so a review run
+    mid-month is not misled into thinking spending is under target.
+    """
     if not budgets:
         return []
 
     by_merchant = stats.get('by_merchant', {})
     all_months = sorted(stats.get('by_month', {}).keys())
     num_months = len(all_months) or stats.get('num_months', 0)
+    excluded_month = all_months[-1] if (all_months and not latest_month_complete) else ''
 
     # Pre-compute each merchant's monthly spend once, then fan out to budgets.
     merchant_spend = []
@@ -329,6 +360,7 @@ def evaluate_budgets(budgets: List[Budget], stats) -> List[BudgetResult]:
             actual_by_month=actual_by_month,
             num_months=num_months,
             matched_merchants=matched,
+            excluded_month=excluded_month,
         ))
 
     # Worst overspend first so a review starts with the problems.
@@ -381,13 +413,17 @@ def find_unmatched_budgets(results: List[BudgetResult], stats) -> List[Dict[str,
     return problems
 
 
-def build_budget_report(config, stats) -> Dict[str, Any]:
-    """Parse and evaluate budgets, returning everything the outputs need."""
+def build_budget_report(config, stats, latest_month_complete: bool = True) -> Dict[str, Any]:
+    """Parse and evaluate budgets, returning everything the outputs need.
+
+    ``latest_month_complete`` is forwarded to :func:`evaluate_budgets` so a
+    partial final month does not deflate the monthly averages.
+    """
     budgets = parse_budgets(config)
     if not budgets:
         return {'enabled': False, 'results': [], 'problems': []}
 
-    results = evaluate_budgets(budgets, stats)
+    results = evaluate_budgets(budgets, stats, latest_month_complete=latest_month_complete)
     return {
         'enabled': True,
         'results': results,

--- a/src/tally/budgets.py
+++ b/src/tally/budgets.py
@@ -1,0 +1,406 @@
+"""
+Budget targets - compare what you planned to spend against what you did spend.
+
+Budgets are declared in settings.yaml and are entirely optional:
+
+    budgets:
+      total: 5000                             # all spending, per month
+      Food: 800                               # a category, per month
+      Food/Groceries: 500                     # a category/subcategory
+      tag:business: 400                       # everything tagged 'business'
+      Travel:                                 # an annual pot rather than monthly
+        amount: 6000
+        period: yearly
+
+Only real spending counts toward a budget. Income, transfers and investment
+contributions are excluded, and refunds reduce the spend for the month they
+land in, so the numbers reconcile with the spending total in the report.
+"""
+
+import difflib
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+from .classification import categorize_amount
+
+# Budget scope types
+SCOPE_TOTAL = 'total'
+SCOPE_CATEGORY = 'category'
+SCOPE_SUBCATEGORY = 'subcategory'
+SCOPE_TAG = 'tag'
+
+# Period types
+PERIOD_MONTHLY = 'monthly'
+PERIOD_YEARLY = 'yearly'
+VALID_PERIODS = (PERIOD_MONTHLY, PERIOD_YEARLY)
+
+# A budget within this fraction of its target is flagged as 'near' rather than
+# 'under', so the report can warn before the limit is actually breached.
+NEAR_THRESHOLD = 0.9
+
+TOTAL_KEY = 'total'
+TAG_PREFIX = 'tag:'
+
+
+class BudgetConfigError(ValueError):
+    """Raised when the budgets block in settings.yaml cannot be understood."""
+
+
+@dataclass
+class Budget:
+    """A single parsed budget target."""
+    key: str
+    scope_type: str
+    target: float
+    period: str = PERIOD_MONTHLY
+    category: Optional[str] = None
+    subcategory: Optional[str] = None
+    tag: Optional[str] = None
+
+    @property
+    def label(self) -> str:
+        if self.scope_type == SCOPE_TOTAL:
+            return 'Total spending'
+        if self.scope_type == SCOPE_TAG:
+            return f"Tagged: {self.tag}"
+        if self.scope_type == SCOPE_SUBCATEGORY:
+            return f"{self.category}/{self.subcategory}"
+        return self.category or self.key
+
+    def matches(self, category: str, subcategory: str, tags) -> bool:
+        """Does a merchant fall inside this budget's scope?"""
+        if self.scope_type == SCOPE_TOTAL:
+            return True
+        if self.scope_type == SCOPE_TAG:
+            return self.tag in {str(t).lower() for t in (tags or [])}
+        if (category or '').lower() != (self.category or '').lower():
+            return False
+        if self.scope_type == SCOPE_SUBCATEGORY:
+            return (subcategory or '').lower() == (self.subcategory or '').lower()
+        return True
+
+
+@dataclass
+class BudgetResult:
+    """A budget evaluated against actual spending."""
+    budget: Budget
+    actual_total: float
+    actual_by_month: Dict[str, float] = field(default_factory=dict)
+    num_months: int = 0
+    matched_merchants: int = 0
+
+    @property
+    def key(self) -> str:
+        return self.budget.key
+
+    @property
+    def label(self) -> str:
+        return self.budget.label
+
+    @property
+    def period(self) -> str:
+        return self.budget.period
+
+    @property
+    def target(self) -> float:
+        """Target for the period the budget is expressed in."""
+        return self.budget.target
+
+    @property
+    def target_for_range(self) -> float:
+        """Target scaled to the date range actually present in the data."""
+        if self.budget.period == PERIOD_YEARLY:
+            return self.budget.target * (self.num_months / 12) if self.num_months else self.budget.target
+        return self.budget.target * self.num_months
+
+    @property
+    def actual_monthly_avg(self) -> float:
+        return self.actual_total / self.num_months if self.num_months else 0.0
+
+    @property
+    def comparison_actual(self) -> float:
+        """The actual figure compared against ``target``."""
+        if self.budget.period == PERIOD_YEARLY:
+            return self.actual_total
+        return self.actual_monthly_avg
+
+    @property
+    def variance(self) -> float:
+        """Positive means over budget."""
+        return self.comparison_actual - self.target
+
+    @property
+    def pct_used(self) -> float:
+        if self.target <= 0:
+            # A zero target cannot be divided into, but any spend against it is
+            # a full breach rather than 0% used.
+            return 100.0 if self.comparison_actual > 0 else 0.0
+        return self.comparison_actual / self.target * 100
+
+    @property
+    def status(self) -> str:
+        if self.target <= 0:
+            return 'over' if self.comparison_actual > 0 else 'under'
+        ratio = self.comparison_actual / self.target
+        if ratio > 1:
+            return 'over'
+        if ratio >= NEAR_THRESHOLD:
+            return 'near'
+        return 'under'
+
+    @property
+    def months_over(self) -> int:
+        """Months whose spend exceeded a monthly target (monthly budgets only)."""
+        if self.budget.period != PERIOD_MONTHLY:
+            return 0
+        return sum(1 for amount in self.actual_by_month.values() if amount > self.target)
+
+    @property
+    def worst_month(self):
+        if not self.actual_by_month:
+            return None
+        month, amount = max(self.actual_by_month.items(), key=lambda kv: kv[1])
+        return {'month': month, 'amount': round(amount, 2)}
+
+    @property
+    def latest_month(self):
+        if not self.actual_by_month:
+            return None
+        month = max(self.actual_by_month)
+        return {'month': month, 'amount': round(self.actual_by_month[month], 2)}
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            'key': self.key,
+            'label': self.label,
+            'scope': self.budget.scope_type,
+            'period': self.period,
+            'target': round(self.target, 2),
+            'target_for_range': round(self.target_for_range, 2),
+            'actual_total': round(self.actual_total, 2),
+            'actual_monthly_avg': round(self.actual_monthly_avg, 2),
+            'variance': round(self.variance, 2),
+            'pct_used': round(self.pct_used, 1),
+            'status': self.status,
+            'months_over': self.months_over,
+            'num_months': self.num_months,
+            'matched_merchants': self.matched_merchants,
+            'by_month': {m: round(v, 2) for m, v in sorted(self.actual_by_month.items())},
+            'worst_month': self.worst_month,
+            'latest_month': self.latest_month,
+        }
+
+
+def _parse_target(key: str, raw: Any) -> Budget:
+    """Parse one ``key: value`` pair from the budgets block."""
+    period = PERIOD_MONTHLY
+
+    if isinstance(raw, dict):
+        if 'amount' not in raw:
+            raise BudgetConfigError(
+                f"Budget '{key}' is missing 'amount'.\n"
+                f"  Use either:\n"
+                f"    {key}: 500\n"
+                f"  or:\n"
+                f"    {key}:\n"
+                f"      amount: 500\n"
+                f"      period: yearly"
+            )
+        amount = raw['amount']
+        period = str(raw.get('period', PERIOD_MONTHLY)).lower()
+        if period not in VALID_PERIODS:
+            raise BudgetConfigError(
+                f"Budget '{key}' has an unknown period '{raw.get('period')}'.\n"
+                f"  Use one of: {', '.join(VALID_PERIODS)}"
+            )
+    else:
+        amount = raw
+
+    if isinstance(amount, bool) or not isinstance(amount, (int, float)):
+        raise BudgetConfigError(
+            f"Budget '{key}' must be a number, got: {amount!r}\n"
+            f"  Example:\n"
+            f"    {key}: 500"
+        )
+    if amount < 0:
+        raise BudgetConfigError(
+            f"Budget '{key}' must not be negative, got: {amount}\n"
+            f"  Budgets are spending limits, so use a positive number."
+        )
+
+    if key.lower() == TOTAL_KEY:
+        return Budget(key=key, scope_type=SCOPE_TOTAL, target=float(amount), period=period)
+
+    if key.lower().startswith(TAG_PREFIX):
+        tag = key[len(TAG_PREFIX):].strip().lower()
+        if not tag:
+            raise BudgetConfigError(
+                f"Budget '{key}' is missing a tag name.\n"
+                f"  Example:\n"
+                f"    tag:business: 400"
+            )
+        return Budget(key=key, scope_type=SCOPE_TAG, target=float(amount), period=period, tag=tag)
+
+    if '/' in key:
+        category, _, subcategory = key.partition('/')
+        category, subcategory = category.strip(), subcategory.strip()
+        if not category or not subcategory:
+            raise BudgetConfigError(
+                f"Budget '{key}' is not a valid Category/Subcategory.\n"
+                f"  Example:\n"
+                f"    Food/Groceries: 500"
+            )
+        return Budget(key=key, scope_type=SCOPE_SUBCATEGORY, target=float(amount),
+                      period=period, category=category, subcategory=subcategory)
+
+    return Budget(key=key, scope_type=SCOPE_CATEGORY, target=float(amount),
+                  period=period, category=key.strip())
+
+
+def parse_budgets(config) -> List[Budget]:
+    """Parse the optional ``budgets`` block from settings.
+
+    Raises:
+        BudgetConfigError: with an actionable message if the block is malformed.
+    """
+    raw = (config or {}).get('budgets')
+    if not raw:
+        return []
+
+    if not isinstance(raw, dict):
+        raise BudgetConfigError(
+            "Setting 'budgets' must be a mapping of target names to amounts.\n"
+            "  Example:\n"
+            "    budgets:\n"
+            "      total: 5000\n"
+            "      Food: 800\n"
+            "      Food/Groceries: 500"
+        )
+
+    return [_parse_target(str(key), value) for key, value in raw.items()]
+
+
+def _merchant_spend_by_month(data) -> Dict[str, float]:
+    """Net spending per month for one merchant (purchases minus refunds)."""
+    by_month: Dict[str, float] = {}
+    for txn in data.get('transactions', []):
+        bucket = categorize_amount(txn.get('amount', 0), txn.get('tags', []))
+        net = bucket['spending'] - bucket['credits']
+        if net:
+            month = txn.get('month', '')
+            by_month[month] = by_month.get(month, 0.0) + net
+    return by_month
+
+
+def evaluate_budgets(budgets: List[Budget], stats) -> List[BudgetResult]:
+    """Evaluate parsed budgets against analysis results."""
+    if not budgets:
+        return []
+
+    by_merchant = stats.get('by_merchant', {})
+    all_months = sorted(stats.get('by_month', {}).keys())
+    num_months = len(all_months) or stats.get('num_months', 0)
+
+    # Pre-compute each merchant's monthly spend once, then fan out to budgets.
+    merchant_spend = []
+    for name, data in by_merchant.items():
+        merchant_spend.append((
+            data.get('category', ''),
+            data.get('subcategory', ''),
+            data.get('tags', set()),
+            _merchant_spend_by_month(data),
+        ))
+
+    results = []
+    for budget in budgets:
+        actual_by_month: Dict[str, float] = {month: 0.0 for month in all_months}
+        matched = 0
+        for category, subcategory, tags, spend_by_month in merchant_spend:
+            if not budget.matches(category, subcategory, tags):
+                continue
+            if spend_by_month:
+                matched += 1
+            for month, amount in spend_by_month.items():
+                actual_by_month[month] = actual_by_month.get(month, 0.0) + amount
+
+        results.append(BudgetResult(
+            budget=budget,
+            actual_total=sum(actual_by_month.values()),
+            actual_by_month=actual_by_month,
+            num_months=num_months,
+            matched_merchants=matched,
+        ))
+
+    # Worst overspend first so a review starts with the problems.
+    results.sort(key=lambda r: (-r.pct_used, r.label))
+    return results
+
+
+def find_unmatched_budgets(results: List[BudgetResult], stats) -> List[Dict[str, Any]]:
+    """Flag budgets that matched nothing, with a suggestion for what to use.
+
+    A silent zero is the worst outcome for a budget review, because it looks
+    like perfect discipline when it actually means the name was wrong.
+    """
+    by_merchant = stats.get('by_merchant', {})
+    categories = sorted({d.get('category', '') for d in by_merchant.values() if d.get('category')})
+    subcategories = sorted({
+        f"{d.get('category', '')}/{d.get('subcategory', '')}"
+        for d in by_merchant.values() if d.get('category') and d.get('subcategory')
+    })
+    tags = sorted({str(t).lower() for d in by_merchant.values() for t in (d.get('tags') or set())})
+
+    problems = []
+    for result in results:
+        if result.matched_merchants:
+            continue
+
+        budget = result.budget
+        if budget.scope_type == SCOPE_TOTAL:
+            # Nothing to correct: 'total' names no category or tag, so an empty
+            # result means there was no spending, not a typo.
+            continue
+
+        if budget.scope_type == SCOPE_TAG:
+            candidates, prefix = tags, TAG_PREFIX
+        elif budget.scope_type == SCOPE_SUBCATEGORY:
+            candidates, prefix = subcategories, ''
+        else:
+            candidates, prefix = categories, ''
+
+        lookup = budget.tag if budget.scope_type == SCOPE_TAG else budget.key
+        close = difflib.get_close_matches(lookup, candidates, n=3, cutoff=0.6)
+        suggestion = close or candidates[:5]
+
+        problems.append({
+            'key': budget.key,
+            'scope': budget.scope_type,
+            'suggestions': [f"{prefix}{c}" for c in suggestion],
+        })
+
+    return problems
+
+
+def build_budget_report(config, stats) -> Dict[str, Any]:
+    """Parse and evaluate budgets, returning everything the outputs need."""
+    budgets = parse_budgets(config)
+    if not budgets:
+        return {'enabled': False, 'results': [], 'problems': []}
+
+    results = evaluate_budgets(budgets, stats)
+    return {
+        'enabled': True,
+        'results': results,
+        'problems': find_unmatched_budgets(results, stats),
+    }
+
+
+def budget_report_to_dict(report: Dict[str, Any]) -> Dict[str, Any]:
+    """Convert a budget report to plain JSON-serializable data."""
+    results = report.get('results', [])
+    return {
+        'enabled': report.get('enabled', False),
+        'over_count': sum(1 for r in results if r.status == 'over'),
+        'targets': [r.to_dict() for r in results],
+        'problems': report.get('problems', []),
+    }

--- a/src/tally/commands/diag.py
+++ b/src/tally/commands/diag.py
@@ -551,6 +551,45 @@ def cmd_diag(args):
         print("    filter: months >= 6 and cv < 0.3")
     print()
 
+    # Budgets configuration
+    print("BUDGETS")
+    print("-" * 70)
+    budget_error = config.get('_budget_error') if config else None
+    budgets = config.get('_budgets') if config else None
+    if budget_error:
+        print(f"  {C.RED}✗{C.RESET}  Invalid 'budgets' block in settings.yaml")
+        for line in budget_error.splitlines():
+            print(f"     {line}")
+    elif budgets:
+        print(f"Targets defined: {len(budgets)}")
+        print()
+        for budget in budgets:
+            period = 'per year' if budget.period == 'yearly' else 'per month'
+            print(f"  [{budget.key}]")
+            print(f"    scope: {budget.scope_type}")
+            print(f"    target: {budget.target:,.2f} {period}")
+    else:
+        print("Not configured (optional)")
+        print("  To track spending against targets, add to settings.yaml:")
+        print("    budgets:")
+        print("      total: 5000            # all spending, per month")
+        print("      Food: 800              # a category")
+        print("      Food/Groceries: 500    # a subcategory")
+        print("      tag:business: 400      # everything with a tag")
+    print()
+
+    # Duplicate detection
+    print("DUPLICATE CHECK")
+    print("-" * 70)
+    if config and config.get('duplicate_check', True):
+        print("Enabled (default)")
+        print("  Warns when the same date, amount and description appear in more")
+        print("  than one file, which usually means two exports overlap.")
+        print("  Disable with: duplicate_check: false")
+    else:
+        print("Disabled via 'duplicate_check: false' in settings.yaml")
+    print()
+
     # JSON output option
     if args.format == 'json':
         print("JSON OUTPUT")
@@ -562,6 +601,15 @@ def cmd_diag(args):
             'settings_file': settings_path,
             'settings_exists': os.path.exists(settings_path),
             'data_sources': [],
+            'budgets': {
+                'configured': bool(budgets),
+                'error': budget_error,
+                'targets': [
+                    {'key': b.key, 'scope': b.scope_type, 'target': b.target, 'period': b.period}
+                    for b in (budgets or [])
+                ],
+            },
+            'duplicate_check': bool(config.get('duplicate_check', True)) if config else True,
             'rules': {
                 'user_rules_path': diag['user_rules_path'],
                 'user_rules_exists': diag['user_rules_exists'],

--- a/src/tally/commands/run.py
+++ b/src/tally/commands/run.py
@@ -276,9 +276,14 @@ def cmd_run(args):
     if not args.quiet:
         print_duplicate_warning(duplicate_report, currency_format, verbose)
 
-    # Budgets and anomalies
-    budget_report = build_budget_report(config, stats)
+    # Budgets and anomalies. Anomaly detection works out whether the newest
+    # month is only partially covered; the budget report needs that so a
+    # mid-month review is not flattered by the partial month's low spend.
     anomaly_report = detect_anomalies(stats, fmt=fmt_money)
+    budget_report = build_budget_report(
+        config, stats,
+        latest_month_complete=anomaly_report.get('latest_month_complete', True),
+    )
 
     # Classify by user-defined views
     views_config = config.get('sections')

--- a/src/tally/commands/run.py
+++ b/src/tally/commands/run.py
@@ -23,6 +23,9 @@ from ..analyzer import (
     analyze_transactions,
     print_summary,
     print_sections_summary,
+    print_budget_summary,
+    print_anomaly_summary,
+    print_duplicate_warning,
     write_summary_file_vue,
     export_json,
     export_csv,
@@ -31,6 +34,10 @@ from ..analyzer import (
     format_diff_summary,
     format_diff_detailed,
 )
+from ..budgets import build_budget_report
+from ..anomalies import detect_anomalies
+from ..duplicates import build_duplicate_report
+from ..report import format_currency_decimal
 from ..parsers import ParseResult, SkippedRow
 from collections import Counter
 
@@ -53,6 +60,14 @@ def cmd_run(args):
 
     # Check for deprecated settings
     check_deprecated_description_cleaning(config)
+
+    # A malformed budgets block is a config error, not something to skip past:
+    # silently dropping targets during a budget review would be misleading.
+    if config.get('_budget_error'):
+        print(f"Error: Invalid 'budgets' in {args.settings}:", file=sys.stderr)
+        print(config['_budget_error'], file=sys.stderr)
+        print(f"\nRun 'tally diag --config {config_dir}' for more details.", file=sys.stderr)
+        sys.exit(1)
 
     # Get report title (new) or year (deprecated)
     title = config.get('title')
@@ -154,6 +169,11 @@ def cmd_run(args):
                     print(f"  {source['name']}: Error parsing {filepath} - {e}")
                 continue
 
+            # Remember the originating file so duplicate detection can tell
+            # an overlapping export from a genuine repeat charge.
+            for txn in txns:
+                txn.setdefault('source_file', filepath)
+
             source_txns.extend(txns)
             source_skipped.extend(skipped)
 
@@ -245,6 +265,21 @@ def cmd_run(args):
     # Analyze
     stats = analyze_transactions(all_txns)
 
+    currency_format = config.get('currency_format', '${amount}')
+
+    def fmt_money(amount):
+        return format_currency_decimal(amount, currency_format)
+
+    # Data quality first: if two exports overlap, every number below is
+    # inflated, so the warning belongs before the report rather than after it.
+    duplicate_report = build_duplicate_report(all_txns, enabled=config.get('duplicate_check', True))
+    if not args.quiet:
+        print_duplicate_warning(duplicate_report, currency_format, verbose)
+
+    # Budgets and anomalies
+    budget_report = build_budget_report(config, stats)
+    anomaly_report = detect_anomalies(stats, fmt=fmt_money)
+
     # Classify by user-defined views
     views_config = config.get('sections')
     if views_config:
@@ -278,18 +313,27 @@ def cmd_run(args):
             if not only_filter:
                 only_filter = None
     category_filter = args.category if hasattr(args, 'category') and args.category else None
-    currency_format = config.get('currency_format', '${amount}')
+
+    def print_review_sections():
+        """Budgets and anomalies, shown after the main spending summary."""
+        print_budget_summary(budget_report, currency_format,
+                             anomaly_report.get('latest_month_complete', True))
+        print_anomaly_summary(anomaly_report, currency_format)
 
     if output_format == 'json':
         # JSON output with reasoning
-        print(export_json(stats, verbose=verbose, category_filter=category_filter))
+        print(export_json(stats, verbose=verbose, category_filter=category_filter,
+                          budgets=budget_report, anomalies=anomaly_report,
+                          duplicates=duplicate_report))
     elif output_format == 'csv':
         # CSV output (transaction-level)
         print(export_csv(stats, category_filter=category_filter))
     elif output_format == 'markdown':
         # Markdown output with reasoning
         from ..analyzer import export_markdown
-        print(export_markdown(stats, verbose=verbose, category_filter=category_filter, currency_format=currency_format))
+        print(export_markdown(stats, verbose=verbose, category_filter=category_filter,
+                              currency_format=currency_format, budgets=budget_report,
+                              anomalies=anomaly_report, duplicates=duplicate_report))
     elif output_format == 'summary' or args.summary:
         # Text summary only (no HTML)
         group_by = getattr(args, 'group_by', 'merchant')
@@ -297,6 +341,7 @@ def cmd_run(args):
             print_sections_summary(stats, title=title, currency_format=currency_format, only_filter=only_filter)
         else:
             print_summary(stats, title=title, currency_format=currency_format, group_by=group_by)
+        print_review_sections()
     else:
         # HTML output (default)
         # Print summary first
@@ -306,6 +351,7 @@ def cmd_run(args):
                 print_sections_summary(stats, title=title, currency_format=currency_format, only_filter=only_filter)
             else:
                 print_summary(stats, title=title, currency_format=currency_format, group_by=group_by)
+            print_review_sections()
 
         # Determine output path
         if args.output:
@@ -315,11 +361,36 @@ def cmd_run(args):
             os.makedirs(output_dir, exist_ok=True)
             output_path = os.path.join(output_dir, config.get('html_filename', 'spending_summary.html'))
 
+        # Make sure the destination exists before writing. A missing --output
+        # directory used to surface as a raw FileNotFoundError traceback.
+        output_parent = os.path.dirname(os.path.abspath(output_path))
+        try:
+            os.makedirs(output_parent, exist_ok=True)
+        except OSError as e:
+            print(f"Error: Cannot create output directory: {output_parent}", file=sys.stderr)
+            print(f"  {e.strerror}", file=sys.stderr)
+            print(f"\nCheck the path passed to --output, or pick a writable location:", file=sys.stderr)
+            print(f"  tally up --config {config_dir} --output ./output/spending.html", file=sys.stderr)
+            sys.exit(1)
+
+        if os.path.isdir(output_path):
+            print(f"Error: --output points to a directory, not a file: {output_path}", file=sys.stderr)
+            print(f"\nInclude a filename:", file=sys.stderr)
+            print(f"  tally up --config {config_dir} --output {os.path.join(output_path, 'spending.html')}", file=sys.stderr)
+            sys.exit(1)
+
         # Collect source names for the report subtitle (exclude supplemental)
         source_names = [s.get('name', 'Unknown') for s in data_sources if not s.get('_supplemental', False)]
-        write_summary_file_vue(stats, output_path, title=title,
-                               currency_format=currency_format, sources=source_names,
-                               embedded_html=args.embedded_html)
+        try:
+            write_summary_file_vue(stats, output_path, title=title,
+                                   currency_format=currency_format, sources=source_names,
+                                   embedded_html=args.embedded_html,
+                                   budgets=budget_report, anomalies=anomaly_report,
+                                   duplicates=duplicate_report)
+        except OSError as e:
+            print(f"Error: Could not write report to {output_path}", file=sys.stderr)
+            print(f"  {e.strerror}", file=sys.stderr)
+            sys.exit(1)
         if not args.quiet:
             # Make the path clickable using OSC 8 hyperlink escape sequence
             abs_path = os.path.abspath(output_path)
@@ -342,7 +413,8 @@ def cmd_run(args):
                 prev_data = None
 
         # Generate and save current JSON
-        curr_json = export_json(stats, verbose=verbose)
+        curr_json = export_json(stats, verbose=verbose, budgets=budget_report,
+                                anomalies=anomaly_report, duplicates=duplicate_report)
         curr_data = json.loads(curr_json)
 
         with open(json_path, 'w') as f:

--- a/src/tally/commands/workflow.py
+++ b/src/tally/commands/workflow.py
@@ -136,12 +136,29 @@ def cmd_workflow(args):
     cmds = [
         ("tally up", "Generate HTML spending report"),
         ("tally up --summary", "Quick text summary"),
+        ("tally up --diff", "Compare against the previous run"),
         ("tally discover", "Find unknown merchants"),
         ("tally explain <merchant>", "Show category and rules"),
         ("tally diag", "Diagnose config issues"),
     ]
     for cmd, desc in cmds:
         print(f"    {C.GREEN}{cmd:<24}{C.RESET} {C.DIM}{desc}{C.RESET}")
+
+    section("Budgets")
+    print(f"    {C.DIM}Set monthly targets to compare planned against actual spending.{C.RESET}")
+    print(f"    {C.DIM}Add to {C.RESET}{C.CYAN}{path_settings}{C.RESET}{C.DIM}:{C.RESET}")
+    print()
+    print(f"    {C.DIM}budgets:")
+    print(f"      total: 5000            # all spending, per month")
+    print(f"      Food: 800              # a category")
+    print(f"      Food/Groceries: 500    # a subcategory")
+    print(f"      tag:business: 400      # everything with a tag")
+    print(f"      Travel:                # an annual pot instead")
+    print(f"        amount: 6000")
+    print(f"        period: yearly{C.RESET}")
+    print()
+    print(f"    {C.DIM}Budgets show in every output format, and{C.RESET} {C.GREEN}tally up{C.RESET} {C.DIM}also flags")
+    print(f"    price rises, new merchants and missing recurring charges.{C.RESET}")
 
     section("Field Transforms")
     print(f"    {C.DIM}Strip payment processor prefixes before matching rules.{C.RESET}")

--- a/src/tally/config_loader.py
+++ b/src/tally/config_loader.py
@@ -11,6 +11,7 @@ import yaml
 from .format_parser import parse_format_string, is_special_parser_type
 from .section_engine import load_sections, SectionParseError
 from .path_utils import resolve_data_source_paths
+from .budgets import parse_budgets, BudgetConfigError
 
 
 def load_settings(config_dir, settings_file='settings.yaml'):
@@ -209,6 +210,22 @@ def load_config(config_dir, settings_file='settings.yaml'):
         })
         rule_mode = 'first_match'
     config['rule_mode'] = rule_mode
+
+    # Duplicate transaction detection (default on). Overlapping exports are easy
+    # to create with folder/glob sources and silently double count.
+    duplicate_check = config.get('duplicate_check', True)
+    if isinstance(duplicate_check, str):
+        duplicate_check = duplicate_check.strip().lower() not in ('off', 'false', 'no', '0')
+    config['duplicate_check'] = bool(duplicate_check)
+
+    # Budget targets (optional). Parsed here so that a malformed block is
+    # reported once, with the same message, by every command.
+    config['_budgets'] = []
+    config['_budget_error'] = None
+    try:
+        config['_budgets'] = parse_budgets(config)
+    except BudgetConfigError as e:
+        config['_budget_error'] = str(e)
 
 
     # Load merchants file (optional - merchants_file in settings.yaml)

--- a/src/tally/duplicates.py
+++ b/src/tally/duplicates.py
@@ -1,0 +1,168 @@
+"""
+Duplicate transaction detection.
+
+Tally concatenates every configured data source into one transaction list. That
+is usually what you want, but it means overlapping exports silently double
+count. This is easy to hit once a source uses a folder or glob pattern:
+
+    data_sources:
+      - name: Checking
+        file: data/exports/*.csv     # 2025-01.csv and 2025-Q1.csv both have Jan
+
+Detection is deliberately conservative. A duplicate is only reported when the
+date, the amount and the normalized description all match exactly, because a
+false alarm during a budget review is worse than a missed one.
+
+Two kinds are reported separately:
+
+    cross_file  Same transaction found in more than one file. Almost always an
+                overlapping export, so this is warned about by default.
+    same_file   The same transaction repeated inside a single file. Often
+                legitimate (two identical coffees on one day), so this is only
+                shown on request.
+"""
+
+import os
+import re
+from collections import defaultdict
+from dataclasses import dataclass, field
+from typing import Any, Dict, List
+
+# Kinds of duplicate groups
+CROSS_FILE = 'cross_file'
+SAME_FILE = 'same_file'
+
+_NON_ALNUM = re.compile(r'[^A-Z0-9]+')
+
+
+def normalize_description(description: str) -> str:
+    """Normalize a description for duplicate comparison.
+
+    Upper-cases and strips punctuation/whitespace so that trivial formatting
+    differences between two exports of the same transaction still match.
+    """
+    if not description:
+        return ''
+    return _NON_ALNUM.sub(' ', description.upper()).strip()
+
+
+@dataclass
+class DuplicateGroup:
+    """A set of transactions that look like the same real-world transaction."""
+    date: str
+    amount: float
+    description: str
+    kind: str
+    count: int
+    sources: List[str] = field(default_factory=list)
+    files: List[str] = field(default_factory=list)
+    merchant: str = ''
+
+    @property
+    def impact(self) -> float:
+        """Absolute amount that is double counted by this group."""
+        return abs(self.amount) * (self.count - 1)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            'date': self.date,
+            'amount': round(self.amount, 2),
+            'description': self.description,
+            'merchant': self.merchant,
+            'kind': self.kind,
+            'count': self.count,
+            'sources': self.sources,
+            'files': [os.path.basename(f) for f in self.files],
+            'impact': round(self.impact, 2),
+        }
+
+
+def _transaction_key(txn):
+    date = txn.get('date')
+    date_key = date.strftime('%Y-%m-%d') if hasattr(date, 'strftime') else str(date)
+    description = txn.get('raw_description') or txn.get('description') or ''
+    return date_key, round(float(txn.get('amount', 0) or 0), 2), normalize_description(description)
+
+
+def find_duplicates(transactions) -> List[DuplicateGroup]:
+    """Find groups of transactions that appear to be duplicates.
+
+    Args:
+        transactions: Parsed transaction dicts. ``source_file`` is used to tell
+            cross-file duplicates from repeats within one file; when it is
+            missing the source name is used instead.
+
+    Returns:
+        List of DuplicateGroup, cross-file first, then by descending impact.
+    """
+    groups = defaultdict(list)
+    for txn in transactions:
+        groups[_transaction_key(txn)].append(txn)
+
+    results = []
+    for (date_key, amount, _), txns in groups.items():
+        if len(txns) < 2:
+            continue
+
+        files = []
+        sources = []
+        for txn in txns:
+            source_file = txn.get('source_file') or txn.get('source') or ''
+            if source_file not in files:
+                files.append(source_file)
+            source = txn.get('source') or ''
+            if source and source not in sources:
+                sources.append(source)
+
+        kind = CROSS_FILE if len(files) > 1 else SAME_FILE
+        first = txns[0]
+        results.append(DuplicateGroup(
+            date=date_key,
+            amount=amount,
+            description=first.get('raw_description') or first.get('description') or '',
+            kind=kind,
+            count=len(txns),
+            sources=sources,
+            files=files,
+            merchant=first.get('merchant', ''),
+        ))
+
+    results.sort(key=lambda g: (g.kind != CROSS_FILE, -g.impact, g.date))
+    return results
+
+
+def build_duplicate_report(transactions, enabled: bool = True) -> Dict[str, Any]:
+    """Build the duplicate summary consumed by the CLI, JSON export and report.
+
+    Returns a dict with ``cross_file`` and ``same_file`` group lists plus the
+    total double-counted amount. Returns an empty (disabled) report when
+    detection is turned off so callers do not need to special-case it.
+    """
+    if not enabled:
+        return {'enabled': False, 'cross_file': [], 'same_file': [],
+                'cross_file_impact': 0.0, 'same_file_impact': 0.0, 'total_count': 0}
+
+    groups = find_duplicates(transactions)
+    cross = [g for g in groups if g.kind == CROSS_FILE]
+    same = [g for g in groups if g.kind == SAME_FILE]
+
+    return {
+        'enabled': True,
+        'cross_file': cross,
+        'same_file': same,
+        'cross_file_impact': sum(g.impact for g in cross),
+        'same_file_impact': sum(g.impact for g in same),
+        'total_count': sum(g.count - 1 for g in groups),
+    }
+
+
+def duplicate_report_to_dict(report: Dict[str, Any]) -> Dict[str, Any]:
+    """Convert a duplicate report to plain JSON-serializable data."""
+    return {
+        'enabled': report.get('enabled', False),
+        'cross_file': [g.to_dict() for g in report.get('cross_file', [])],
+        'same_file': [g.to_dict() for g in report.get('same_file', [])],
+        'cross_file_impact': round(report.get('cross_file_impact', 0.0), 2),
+        'same_file_impact': round(report.get('same_file_impact', 0.0), 2),
+        'total_count': report.get('total_count', 0),
+    }

--- a/src/tally/report.py
+++ b/src/tally/report.py
@@ -50,9 +50,14 @@ def format_currency(amount: float, currency_format: str = "${amount}") -> str:
 
     Returns:
         Formatted currency string, e.g. "$1,234" or "1,234 zl"
+
+    Negative amounts put the minus in front of the whole thing ("-$1,234"),
+    matching formatCurrency() in spending_report.js so the CLI and the HTML
+    report never disagree.
     """
-    formatted_num = f"{amount:,.0f}"
-    return currency_format.format(amount=formatted_num)
+    formatted_num = f"{abs(amount):,.0f}"
+    sign = '-' if round(amount) < 0 else ''
+    return sign + currency_format.format(amount=formatted_num)
 
 
 def format_currency_decimal(amount: float, currency_format: str = "${amount}") -> str:
@@ -64,9 +69,23 @@ def format_currency_decimal(amount: float, currency_format: str = "${amount}") -
 
     Returns:
         Formatted currency string with decimals, e.g. "$1,234.56"
+
+    Negative amounts are rendered as "-$1,234.56" for the same reason as
+    format_currency().
     """
-    formatted_num = f"{amount:,.2f}"
-    return currency_format.format(amount=formatted_num)
+    formatted_num = f"{abs(amount):,.2f}"
+    sign = '-' if round(amount, 2) < 0 else ''
+    return sign + currency_format.format(amount=formatted_num)
+
+
+def format_currency_signed(amount: float, currency_format: str = "${amount}") -> str:
+    """Format an amount with an explicit leading sign.
+
+    The sign goes outside the currency symbol ("-$200.00"), which naive
+    formatting of a negative number would render as "$-200.00".
+    """
+    sign = '+' if amount > 0 else ''
+    return f"{sign}{format_currency_decimal(amount, currency_format)}"
 
 
 # ============================================================================
@@ -91,7 +110,33 @@ def generate_embeddings(items):
 # VUE-BASED HTML REPORT (Modern)
 # ============================================================================
 
-def write_summary_file_vue(stats, filepath, year=None, currency_format="${amount}", sources=None, embedded_html=True, title=None):
+def _budgets_payload(budgets):
+    """Shape the budget report for the Vue app, or None when unused."""
+    if not budgets or not budgets.get('enabled') or not budgets.get('results'):
+        return None
+    from .budgets import budget_report_to_dict
+    return budget_report_to_dict(budgets)
+
+
+def _anomalies_payload(anomalies):
+    """Shape the anomaly report for the Vue app, or None when there is nothing."""
+    if not anomalies or not anomalies.get('enabled') or not anomalies.get('anomalies'):
+        return None
+    from .anomalies import anomaly_report_to_dict
+    return anomaly_report_to_dict(anomalies)
+
+
+def _duplicates_payload(duplicates):
+    """Shape the duplicate report for the Vue app, or None when clean."""
+    if not duplicates or not duplicates.get('enabled') or not duplicates.get('cross_file'):
+        return None
+    from .duplicates import duplicate_report_to_dict
+    return duplicate_report_to_dict(duplicates)
+
+
+def write_summary_file_vue(stats, filepath, year=None, currency_format="${amount}", sources=None,
+                           embedded_html=True, title=None, budgets=None, anomalies=None,
+                           duplicates=None):
     """Write summary to HTML file using Vue 3 for client-side rendering.
 
     Args:
@@ -102,6 +147,9 @@ def write_summary_file_vue(stats, filepath, year=None, currency_format="${amount
         sources: List of data source names (e.g., ['Amex', 'Chase'])
         embedded_html: If True (default), embed CSS/JS inline. If False, output separate files.
         title: Custom report title (e.g., "2025 Budget Analysis")
+        budgets: Optional budget report from budgets.build_budget_report()
+        anomalies: Optional report from anomalies.detect_anomalies()
+        duplicates: Optional report from duplicates.build_duplicate_report()
     """
     sources = sources or []
 
@@ -329,6 +377,11 @@ def write_summary_file_vue(stats, filepath, year=None, currency_format="${amount
         'transfersNet': stats.get('transfers_net', 0),  # in - out
         # Investments (401K, IRA - excluded from spending)
         'investmentTotal': stats.get('investment_total', 0),
+        # Review data. Each key is null when the feature is unused, so the Vue
+        # app can hide the corresponding panel entirely.
+        'budgets': _budgets_payload(budgets),
+        'anomalies': _anomalies_payload(anomalies),
+        'duplicates': _duplicates_payload(duplicates),
     }
 
     # Assemble final HTML

--- a/src/tally/spending_report.css
+++ b/src/tally/spending_report.css
@@ -1449,3 +1449,285 @@ section:nth-child(5) { animation-delay: 0.4s; }
 }
 
 
+
+/* ============================================================
+   REVIEW PANELS - duplicates, budgets, anomalies
+   ============================================================ */
+
+/* ---------- Duplicate warning banner ---------- */
+.duplicate-banner {
+    background: color-mix(in srgb, var(--accent-orange) 12%, transparent);
+    border: 1px solid color-mix(in srgb, var(--accent-orange) 45%, transparent);
+    border-radius: 12px;
+    padding: 1rem 1.25rem;
+    margin-bottom: 1.5rem;
+}
+.duplicate-banner-head {
+    display: flex;
+    align-items: flex-start;
+    gap: 0.75rem;
+}
+.duplicate-icon {
+    color: var(--accent-orange);
+    font-size: 1.2rem;
+    line-height: 1.4;
+}
+.duplicate-headline {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    gap: 0.15rem;
+}
+.duplicate-headline strong {
+    color: var(--text-primary);
+    font-weight: 600;
+}
+.duplicate-sub {
+    color: var(--text-secondary);
+    font-size: 0.875rem;
+}
+.duplicate-dismiss {
+    background: none;
+    border: none;
+    color: var(--text-muted);
+    font-size: 1.4rem;
+    line-height: 1;
+    cursor: pointer;
+    padding: 0 0.25rem;
+}
+.duplicate-dismiss:hover {
+    color: var(--text-primary);
+}
+.duplicate-table {
+    width: 100%;
+    margin-top: 0.75rem;
+    border-collapse: collapse;
+    font-family: 'SF Mono', Monaco, monospace;
+    font-size: 0.8rem;
+    color: var(--text-lighter);
+}
+.duplicate-table td {
+    padding: 0.25rem 0.5rem 0.25rem 0;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+.duplicate-table .dup-amount {
+    text-align: right;
+    color: var(--text-primary);
+}
+.duplicate-table .dup-desc {
+    max-width: 320px;
+    width: 100%;
+}
+.duplicate-table .dup-files {
+    color: var(--text-muted);
+    text-align: right;
+}
+.duplicate-more {
+    background: none;
+    border: 1px solid var(--border-medium);
+    border-radius: 6px;
+    color: var(--text-secondary);
+    cursor: pointer;
+    font-size: 0.8rem;
+    margin-top: 0.5rem;
+    padding: 0.25rem 0.6rem;
+}
+.duplicate-more:hover {
+    color: var(--text-primary);
+    border-color: var(--border-strong);
+}
+.duplicate-hint {
+    color: var(--text-muted);
+    font-size: 0.8rem;
+    margin: 0.75rem 0 0;
+}
+.duplicate-hint code {
+    background: var(--bg-code);
+    border-radius: 4px;
+    padding: 0.1rem 0.35rem;
+}
+
+/* ---------- Budgets ---------- */
+.budget-section,
+.anomaly-section {
+    background: var(--bg-card);
+    border-radius: 16px;
+    padding: 1.5rem;
+    margin-bottom: 2rem;
+}
+.budget-section .section-header,
+.anomaly-section .section-header {
+    margin: -1.5rem -1.5rem 1.5rem -1.5rem;
+    padding: 1rem 1.5rem;
+    border-radius: 16px 16px 0 0;
+}
+.budget-headline,
+.anomaly-headline {
+    font-size: 0.85rem;
+    font-weight: 500;
+    letter-spacing: 0.02em;
+    padding: 0.15rem 0.6rem;
+    border-radius: 999px;
+    background: var(--bg-table-header);
+    color: var(--text-secondary);
+}
+.budget-headline.over {
+    background: color-mix(in srgb, var(--accent-red) 18%, transparent);
+    color: var(--accent-red);
+}
+.budget-headline.ok {
+    background: color-mix(in srgb, var(--accent-green) 15%, transparent);
+    color: var(--accent-green);
+}
+.budget-list {
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: 1.1rem;
+}
+@media (min-width: 900px) {
+    .budget-list {
+        grid-template-columns: repeat(2, 1fr);
+        column-gap: 2rem;
+    }
+}
+.budget-row-head,
+.budget-row-foot {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 1rem;
+}
+.budget-label {
+    color: var(--text-primary);
+    font-weight: 500;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+.budget-numbers {
+    font-family: 'SF Mono', Monaco, monospace;
+    font-size: 0.9rem;
+    white-space: nowrap;
+}
+.budget-numbers strong {
+    color: var(--text-primary);
+}
+.budget-of {
+    color: var(--text-muted);
+    margin-left: 0.35rem;
+}
+.budget-bar {
+    background: var(--bg-table-header);
+    border-radius: 999px;
+    height: 8px;
+    margin: 0.45rem 0 0.35rem;
+    overflow: hidden;
+}
+.budget-bar-fill {
+    height: 100%;
+    border-radius: 999px;
+    transition: width 0.4s ease-out;
+    background: var(--accent-green);
+}
+.budget-row.near .budget-bar-fill {
+    background: var(--accent-yellow);
+}
+.budget-row.over .budget-bar-fill {
+    background: var(--accent-red);
+}
+.budget-row-foot {
+    font-size: 0.8rem;
+    color: var(--text-muted);
+}
+.budget-row.over .budget-status,
+.budget-row.over .budget-variance {
+    color: var(--accent-red);
+}
+.budget-row.near .budget-status,
+.budget-row.near .budget-variance {
+    color: var(--accent-yellow);
+}
+.budget-row.under .budget-status,
+.budget-row.under .budget-variance {
+    color: var(--accent-green);
+}
+.budget-variance {
+    font-family: 'SF Mono', Monaco, monospace;
+    white-space: nowrap;
+}
+.budget-note {
+    color: var(--text-muted);
+    font-size: 0.75rem;
+    margin-top: 0.3rem;
+}
+.budget-problem {
+    background: color-mix(in srgb, var(--accent-orange) 10%, transparent);
+    border-left: 3px solid var(--accent-orange);
+    border-radius: 6px;
+    color: var(--text-secondary);
+    font-size: 0.85rem;
+    margin-top: 1.25rem;
+    padding: 0.6rem 0.9rem;
+}
+.budget-problem strong {
+    color: var(--text-primary);
+}
+.budget-partial {
+    color: var(--text-muted);
+    font-size: 0.8rem;
+    margin: 1rem 0 0;
+}
+
+/* ---------- Worth a look ---------- */
+.anomaly-list {
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
+}
+.anomaly-row {
+    align-items: flex-start;
+    border-radius: 10px;
+    cursor: pointer;
+    display: flex;
+    gap: 0.75rem;
+    padding: 0.6rem 0.75rem;
+    transition: background 0.15s;
+}
+.anomaly-row:hover {
+    background: var(--bg-card-hover);
+}
+.anomaly-icon {
+    line-height: 1.5;
+    width: 1rem;
+    text-align: center;
+    color: var(--text-muted);
+}
+.anomaly-row.warn .anomaly-icon {
+    color: var(--accent-orange);
+}
+.anomaly-body {
+    flex: 1;
+    min-width: 0;
+}
+.anomaly-title {
+    color: var(--text-primary);
+    font-weight: 500;
+}
+.anomaly-detail {
+    color: var(--text-secondary);
+    font-size: 0.85rem;
+    margin-top: 0.1rem;
+}
+.anomaly-impact {
+    color: var(--text-muted);
+    font-family: 'SF Mono', Monaco, monospace;
+    font-size: 0.85rem;
+    white-space: nowrap;
+}
+.anomaly-more {
+    color: var(--text-muted);
+    font-size: 0.8rem;
+    margin: 0.75rem 0 0;
+}

--- a/src/tally/spending_report.html
+++ b/src/tally/spending_report.html
@@ -129,6 +129,113 @@
                 </div>
             </div>
 
+            <!-- Duplicate transaction warning: data quality comes before any
+                 conclusion drawn from the numbers below it. -->
+            <div class="duplicate-banner" data-testid="duplicate-banner"
+                 v-if="duplicateReport && duplicateGroups.length && !duplicatesDismissed">
+                <div class="duplicate-banner-head">
+                    <span class="duplicate-icon">⚠</span>
+                    <div class="duplicate-headline">
+                        <strong>{{ duplicateGroups.length }} transaction{{ duplicateGroups.length === 1 ? '' : 's' }}
+                            appear in more than one file</strong>
+                        <span class="duplicate-sub">
+                            {{ formatCurrency(duplicateReport.cross_file_impact) }} is counted twice in the totals below.
+                        </span>
+                    </div>
+                    <button class="duplicate-dismiss" data-testid="duplicate-dismiss"
+                            @click="duplicatesDismissed = true" title="Dismiss">&times;</button>
+                </div>
+                <table class="duplicate-table">
+                    <tr v-for="(dup, i) in visibleDuplicates" :key="i">
+                        <td class="dup-date">{{ dup.date }}</td>
+                        <td class="dup-amount">{{ formatCurrencySigned(dup.amount) }}</td>
+                        <td class="dup-desc">{{ dup.description }}</td>
+                        <td class="dup-files">{{ dup.files.join(', ') }}</td>
+                    </tr>
+                </table>
+                <button class="duplicate-more" v-if="duplicateGroups.length > 5"
+                        @click="duplicatesExpanded = !duplicatesExpanded">
+                    {{ duplicatesExpanded ? 'Show less' : 'Show all ' + duplicateGroups.length }}
+                </button>
+                <p class="duplicate-hint">
+                    Remove the overlapping export, narrow the glob in settings.yaml, or set
+                    <code>duplicate_check: off</code> if the repeats are real.
+                </p>
+            </div>
+
+            <!-- Budgets -->
+            <div class="budget-section" data-testid="budget-section" v-if="budgetTargets.length">
+                <div class="section-header" @click="budgetsCollapsed = !budgetsCollapsed">
+                    <h2>
+                        <span class="toggle">{{ budgetsCollapsed ? '▶' : '▼' }}</span>
+                        Budgets
+                        <span class="budget-headline" :class="budgetsOverCount ? 'over' : 'ok'">
+                            {{ budgetsOverCount ? budgetsOverCount + ' of ' + budgetTargets.length + ' over budget'
+                                                : 'all ' + budgetTargets.length + ' within budget' }}
+                        </span>
+                    </h2>
+                </div>
+                <div class="section-content" :class="{ collapsed: budgetsCollapsed }">
+                    <div class="budget-list">
+                        <div class="budget-row" v-for="target in budgetTargets" :key="target.key"
+                             :class="target.status" data-testid="budget-row">
+                            <div class="budget-row-head">
+                                <span class="budget-label">{{ target.label }}</span>
+                                <span class="budget-numbers">
+                                    <strong>{{ formatCurrency(target.period === 'yearly' ? target.actual_total : target.actual_monthly_avg) }}</strong>
+                                    <span class="budget-of">of {{ formatCurrency(target.target) }}{{ budgetPeriodSuffix(target) }}</span>
+                                </span>
+                            </div>
+                            <div class="budget-bar">
+                                <div class="budget-bar-fill" :style="{ width: budgetBarWidth(target) }"></div>
+                            </div>
+                            <div class="budget-row-foot">
+                                <span class="budget-status">{{ budgetStatusLabel(target) }} · {{ Math.round(target.pct_used) }}%</span>
+                                <span class="budget-variance">{{ formatCurrencySigned(target.variance) }}{{ budgetPeriodSuffix(target) }}</span>
+                            </div>
+                            <div class="budget-note" v-if="target.months_over">
+                                Over target in {{ target.months_over }} of {{ target.num_months }} months
+                            </div>
+                        </div>
+                    </div>
+                    <div class="budget-problem" v-for="problem in budgetProblems" :key="problem.key">
+                        <strong>Budget "{{ problem.key }}" matched no transactions.</strong>
+                        <span v-if="problem.suggestions.length"> Did you mean: {{ problem.suggestions.join(', ') }}?</span>
+                    </div>
+                    <p class="budget-partial" v-if="anomalyReport && !anomalyReport.latest_month_complete">
+                        The most recent month is partial, so its spend is lower than a full month.
+                    </p>
+                </div>
+            </div>
+
+            <!-- Worth a Look -->
+            <div class="anomaly-section" data-testid="anomaly-section" v-if="anomalyItems.length">
+                <div class="section-header" @click="anomaliesCollapsed = !anomaliesCollapsed">
+                    <h2>
+                        <span class="toggle">{{ anomaliesCollapsed ? '▶' : '▼' }}</span>
+                        Worth a Look
+                        <span class="anomaly-headline">{{ anomalyReport.latest_month }}</span>
+                    </h2>
+                </div>
+                <div class="section-content" :class="{ collapsed: anomaliesCollapsed }">
+                    <div class="anomaly-list">
+                        <div class="anomaly-row" v-for="(item, i) in anomalyItems" :key="i"
+                             :class="item.severity" data-testid="anomaly-row"
+                             @click="item.subject && addFilter(item.subject, anomalyFilterType(item))">
+                            <span class="anomaly-icon">{{ item.severity === 'warn' ? '⚠' : '·' }}</span>
+                            <div class="anomaly-body">
+                                <div class="anomaly-title">{{ item.title }}</div>
+                                <div class="anomaly-detail">{{ item.detail }}</div>
+                            </div>
+                            <span class="anomaly-impact" v-if="item.impact">{{ formatCurrency(item.impact) }}</span>
+                        </div>
+                    </div>
+                    <p class="anomaly-more" v-if="anomalyReport.total_found > anomalyItems.length">
+                        ... and {{ anomalyReport.total_found - anomalyItems.length }} more
+                    </p>
+                </div>
+            </div>
+
             <!-- Charts Section -->
             <div class="chart-section">
                 <div class="section-header" @click="chartsCollapsed = !chartsCollapsed">

--- a/src/tally/spending_report.js
+++ b/src/tally/spending_report.js
@@ -486,6 +486,10 @@ createApp({
         const groupByMode = ref('merchant'); // 'merchant' or 'subcategory'
         const sortConfig = reactive({}); // { 'cat:Food': { column: 'total', dir: 'desc' } }
         const includeNegativeTotals = ref(false); // show categories with negative filteredTotal
+        const budgetsCollapsed = ref(false);
+        const anomaliesCollapsed = ref(false);
+        const duplicatesDismissed = ref(false);
+        const duplicatesExpanded = ref(false);
 
         // Chart refs
         const monthlyChart = ref(null);
@@ -509,6 +513,46 @@ createApp({
             const sources = data.sources || [];
             return sources.length > 0 ? `Data from ${sources.join(', ')}` : '';
         });
+
+        // ---------- Review data (budgets, anomalies, duplicates) ----------
+        // Each of these is null unless the corresponding feature produced
+        // something, so the panels disappear entirely rather than rendering
+        // empty shells.
+        const budgetReport = computed(() => spendingData.value.budgets || null);
+        const budgetTargets = computed(() => (budgetReport.value && budgetReport.value.targets) || []);
+        const budgetProblems = computed(() => (budgetReport.value && budgetReport.value.problems) || []);
+        const budgetsOverCount = computed(() => budgetTargets.value.filter(b => b.status === 'over').length);
+
+        const anomalyReport = computed(() => spendingData.value.anomalies || null);
+        const anomalyItems = computed(() => (anomalyReport.value && anomalyReport.value.items) || []);
+
+        const duplicateReport = computed(() => spendingData.value.duplicates || null);
+        const duplicateGroups = computed(() => (duplicateReport.value && duplicateReport.value.cross_file) || []);
+        const visibleDuplicates = computed(() =>
+            duplicatesExpanded.value ? duplicateGroups.value : duplicateGroups.value.slice(0, 5)
+        );
+
+        // Budget bar width is capped so a 300% overspend still renders a full
+        // bar rather than overflowing its container.
+        function budgetBarWidth(target) {
+            return Math.min(target.pct_used || 0, 100) + '%';
+        }
+
+        function budgetStatusLabel(target) {
+            if (target.status === 'over') return 'Over budget';
+            if (target.status === 'near') return 'Close to limit';
+            return 'Within budget';
+        }
+
+        function budgetPeriodSuffix(target) {
+            return target.period === 'yearly' ? '/yr' : '/mo';
+        }
+
+        // A category_spike anomaly's subject is a category, not a merchant.
+        // Filtering it as a merchant would match nothing and blank the report.
+        function anomalyFilterType(item) {
+            return item.kind === 'category_spike' ? 'category' : 'merchant';
+        }
 
         // Core filtering - returns sections with filtered merchants and transactions
         const filteredSections = computed(() => {
@@ -1536,6 +1580,15 @@ createApp({
             return formatted;
         }
 
+        // Currency with an explicit sign, used for budget variances where the
+        // direction matters as much as the magnitude.
+        function formatCurrencySigned(amount) {
+            const formatted = formatCurrency(Math.abs(amount || 0));
+            if (amount > 0) return '+' + formatted;
+            if (amount < 0) return '-' + formatted;
+            return formatted;
+        }
+
         // Short format for chart Y-axis (e.g., $1k, £1k, 1k zł)
         function formatCurrencyShort(amount) {
             if (amount >= 1000) {
@@ -2002,6 +2055,7 @@ createApp({
             activeFilters, expandedMerchants, extraFieldMatches, collapsedSections, searchQuery,
             showAutocomplete, autocompleteIndex, isScrolled, isDarkTheme, chartsCollapsed, helpCollapsed,
             currentView, groupByMode, sortConfig, includeNegativeTotals,
+            budgetsCollapsed, anomaliesCollapsed, duplicatesDismissed, duplicatesExpanded,
             // Refs
             monthlyChart, categoryPieChart, categoryByMonthChart,
             // Computed
@@ -2017,12 +2071,17 @@ createApp({
             investmentTotal,
             // Filtered view card
             filteredViewTotals,
+            // Review panels
+            budgetReport, budgetTargets, budgetProblems, budgetsOverCount,
+            anomalyReport, anomalyItems,
+            duplicateReport, duplicateGroups, visibleDuplicates,
+            budgetBarWidth, budgetStatusLabel, budgetPeriodSuffix, anomalyFilterType,
             // All transactions section
             groupedTransactions, expandedTransactions,
             // Methods
             addFilter, removeFilter, toggleFilterMode, clearFilters, addMonthFilter,
             toggleExpand, toggleSection, toggleSort, sortedMerchants,
-            formatCurrency, formatDate, formatMonthLabel, formatPct, filterTypeChar,
+            formatCurrency, formatCurrencySigned, formatDate, formatMonthLabel, formatPct, filterTypeChar,
             highlightDescription,
             onSearchInput, onSearchKeydown, selectAutocompleteItem,
             toggleTheme

--- a/src/tally/templates.py
+++ b/src/tally/templates.py
@@ -41,9 +41,24 @@ merchants_file: config/merchants.rules
 #   most_specific         - Most specific rule wins. More conditions = wins.
 # rule_mode: first_match
 
-# Views file (optional) - custom spending views
-# Create config/views.rules and uncomment:
-# views_file: config/views.rules
+# Views file - custom spending views (see config/views.rules)
+views_file: config/views.rules
+
+# Budgets (optional) - monthly spending targets shown in the report.
+# Keys are a category, a Category/Subcategory, 'tag:<name>', or 'total'.
+# Run 'tally up --format summary' to see the category names in your data.
+# budgets:
+#   total: 5000              # all spending, per month
+#   Food: 800                # a whole category
+#   Food/Groceries: 500      # a subcategory
+#   tag:business: 400        # everything tagged 'business'
+#   Travel:                  # an annual pot instead of a monthly one
+#     amount: 6000
+#     period: yearly
+
+# Warn when the same transaction shows up in more than one file, which happens
+# when statement exports overlap. Set to false to silence the check.
+# duplicate_check: true
 
 # Home locations (auto-detected if not specified)
 # Transactions outside these locations are classified as travel
@@ -202,33 +217,42 @@ STARTER_VIEWS = '''# Tally Views Configuration (.rules format)
 #   Membership: "tag" in tags
 #   Arithmetic: +  -  *  /  %
 #
+# Run 'tally reference views' for the full syntax reference.
+
 # ============================================================================
-# SAMPLE VIEWS (uncomment and customize)
+# DEFAULT VIEWS
+# ============================================================================
+# These work with any set of categories because they group by spending
+# *behaviour* rather than by category name. Edit or delete freely - the
+# category breakdown in the report does not depend on them.
+
+[Every Month]
+description: Predictable recurring costs - rent, utilities, subscriptions
+filter: months >= 3 and cv < 0.3
+
+[Variable Recurring]
+description: Frequent but lumpy - groceries, fuel, shopping
+filter: months >= 3 and cv >= 0.3
+
+[Occasional]
+description: Shows up now and then rather than every month
+filter: months >= 2 and months < 3
+
+[One Off]
+description: Single-month spending, including big one-time purchases
+filter: months == 1
+
+# ============================================================================
+# MORE IDEAS (uncomment and customize)
 # ============================================================================
 
-# [Every Month]
-# description: Consistent recurring expenses (rent, utilities, subscriptions)
-# filter: months >= 6 and cv < 0.3
-
-# [Variable Recurring]
-# description: Frequent but inconsistent (groceries, shopping, delivery)
-# filter: months >= 6 and cv >= 0.3
-
-# [Periodic]
-# description: Quarterly or semi-annual (tuition, insurance)
-# filter: months >= 2 and months <= 5
+# [Large Purchases]
+# description: Big one-time expenses over 1,000
+# filter: total > 1000 and months <= 3
 
 # [Travel]
 # description: All travel expenses
 # filter: category == "Travel"
-
-# [Large Purchases]
-# description: Big one-time expenses over $1,000
-# filter: total > 1000 and months <= 3
-
-# [Food & Dining]
-# description: All food-related spending
-# filter: category == "Food"
 
 # [Subscriptions]
 # description: Streaming, software, memberships

--- a/tests/fixtures/rule_snapshot/expected_output.json
+++ b/tests/fixtures/rule_snapshot/expected_output.json
@@ -587,9 +587,9 @@
   },
   "credits": [
     {
-      "amount": 10300.0,
-      "category": "Transfers",
-      "merchant": "Stock Sale Generic"
+      "amount": 125.5,
+      "category": "Subscriptions",
+      "merchant": "Apple Apps"
     }
   ],
   "merchants": [

--- a/tests/test_analyzer.py
+++ b/tests/test_analyzer.py
@@ -1109,10 +1109,19 @@ class TestCurrencyFormatting:
         assert format_currency_decimal(1234.56, "{amount} zł") == "1,234.56 zł"
 
     def test_format_currency_negative(self):
-        """Test negative amount formatting."""
-        from tally.analyzer import format_currency
-        assert format_currency(-1234) == "$-1,234"
+        """Negative amounts put the sign before the currency symbol.
+
+        This matches formatCurrency() in spending_report.js, so the terminal
+        summary and the HTML report render the same value the same way.
+        """
+        from tally.analyzer import format_currency, format_currency_decimal
+        assert format_currency(-1234) == "-$1,234"
         assert format_currency(-1234, "{amount} zł") == "-1,234 zł"
+        assert format_currency(-1234, "€{amount}") == "-€1,234"
+        assert format_currency_decimal(-1234.56) == "-$1,234.56"
+        # Values that round to zero must not pick up a stray minus sign.
+        assert format_currency(-0.4) == "$0"
+        assert format_currency_decimal(-0.001) == "$0.00"
 
 
 class TestRegexDelimiter:

--- a/tests/test_budget_review.py
+++ b/tests/test_budget_review.py
@@ -152,6 +152,26 @@ class TestBudgetEvaluation:
         assert result.status == 'over'
         assert result.variance == 50
 
+    def test_partial_latest_month_is_excluded_from_the_average(self, two_month_stats):
+        # Run mid-month, the newest month (Feb, 300) is only a few days in. It
+        # must not drag the monthly average down and flatter the budget.
+        budgets = parse_budgets({'budgets': {'Food': 200}})
+        result, = evaluate_budgets(budgets, two_month_stats, latest_month_complete=False)
+        # Feb still shows in the total/breakdown, but the average is Jan alone.
+        assert result.actual_total == 500
+        assert result.actual_by_month == {'2025-01': 200, '2025-02': 300}
+        assert result.actual_monthly_avg == 200
+        assert result.variance == 0
+
+    def test_a_single_partial_month_still_averages_over_that_month(self):
+        # With nothing to fall back on, a partial figure beats no figure.
+        stats = stats_for([
+            txn('2025-01-05', 'WHOLEFDS', 120, merchant='Whole Foods'),
+        ])
+        budgets = parse_budgets({'budgets': {'Food': 200}})
+        result, = evaluate_budgets(budgets, stats, latest_month_complete=False)
+        assert result.actual_monthly_avg == 120
+
     def test_months_over_counts_individual_months(self, two_month_stats):
         budgets = parse_budgets({'budgets': {'Food': 250}})
         result, = evaluate_budgets(budgets, two_month_stats)

--- a/tests/test_budget_review.py
+++ b/tests/test_budget_review.py
@@ -1,0 +1,680 @@
+"""
+Tests for budget targets, anomaly detection and duplicate transaction warnings.
+
+These features sit on top of rule processing and drive the "budget review"
+workflow: what did I plan to spend, what did I actually spend, what changed,
+and can I trust the numbers at all.
+"""
+
+import json
+import os
+import subprocess
+import sys
+from datetime import datetime
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), 'src'))
+
+from tally.analyzer import analyze_transactions
+from tally.anomalies import (
+    CATEGORY_SPIKE,
+    LARGE_TRANSACTION,
+    MISSING_RECURRING,
+    NEW_MERCHANT,
+    PRICE_INCREASE,
+    detect_anomalies,
+)
+from tally.budgets import (
+    BudgetConfigError,
+    build_budget_report,
+    evaluate_budgets,
+    parse_budgets,
+)
+from tally.duplicates import (
+    CROSS_FILE,
+    SAME_FILE,
+    build_duplicate_report,
+    find_duplicates,
+    normalize_description,
+)
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+
+def txn(date, description, amount, merchant=None, category='Food',
+        subcategory='Grocery', tags=None, source='Card', source_file='a.csv'):
+    """Build a parsed-transaction dict of the shape the analyzer expects."""
+    return {
+        'date': datetime.strptime(date, '%Y-%m-%d'),
+        'raw_description': description,
+        'description': merchant or description,
+        'merchant': merchant or description,
+        'amount': amount,
+        'category': category,
+        'subcategory': subcategory,
+        'source': source,
+        'source_file': source_file,
+        'tags': tags or [],
+    }
+
+
+def stats_for(transactions):
+    return analyze_transactions(transactions)
+
+
+# =============================================================================
+# Budget parsing
+# =============================================================================
+
+class TestBudgetParsing:
+
+    def test_no_budgets_returns_empty(self):
+        assert parse_budgets({}) == []
+        assert parse_budgets({'budgets': None}) == []
+
+    def test_scalar_is_a_monthly_category_target(self):
+        budget, = parse_budgets({'budgets': {'Food': 800}})
+        assert budget.scope_type == 'category'
+        assert budget.category == 'Food'
+        assert budget.target == 800
+        assert budget.period == 'monthly'
+
+    def test_total_key_covers_all_spending(self):
+        budget, = parse_budgets({'budgets': {'total': 5000}})
+        assert budget.scope_type == 'total'
+        assert budget.label == 'Total spending'
+
+    def test_slash_key_is_a_subcategory(self):
+        budget, = parse_budgets({'budgets': {'Food/Groceries': 500}})
+        assert budget.scope_type == 'subcategory'
+        assert budget.category == 'Food'
+        assert budget.subcategory == 'Groceries'
+
+    def test_tag_prefix_targets_a_tag(self):
+        budget, = parse_budgets({'budgets': {'tag:Business': 400}})
+        assert budget.scope_type == 'tag'
+        assert budget.tag == 'business'
+        assert budget.label == 'Tagged: business'
+
+    def test_dict_form_supports_yearly_period(self):
+        budget, = parse_budgets({'budgets': {'Travel': {'amount': 6000, 'period': 'yearly'}}})
+        assert budget.period == 'yearly'
+        assert budget.target == 6000
+
+    @pytest.mark.parametrize('block,expected', [
+        ({'Food': 'lots'}, 'must be a number'),
+        ({'Food': -5}, 'must not be negative'),
+        ({'Food': {'period': 'yearly'}}, "missing 'amount'"),
+        ({'Food': {'amount': 100, 'period': 'fortnightly'}}, 'unknown period'),
+        ({'tag:': 100}, 'missing a tag name'),
+        ({'Food/': 100}, 'not a valid Category/Subcategory'),
+    ])
+    def test_malformed_budgets_explain_the_fix(self, block, expected):
+        """Error messages must say what is wrong and show a valid example."""
+        with pytest.raises(BudgetConfigError) as exc:
+            parse_budgets({'budgets': block})
+        message = str(exc.value)
+        assert expected in message
+        # Every message should carry a concrete example to copy.
+        assert ':' in message and '\n' in message
+
+    def test_budgets_must_be_a_mapping(self):
+        with pytest.raises(BudgetConfigError) as exc:
+            parse_budgets({'budgets': ['Food: 800']})
+        assert 'mapping' in str(exc.value)
+
+
+# =============================================================================
+# Budget evaluation
+# =============================================================================
+
+class TestBudgetEvaluation:
+
+    @pytest.fixture
+    def two_month_stats(self):
+        return stats_for([
+            txn('2025-01-05', 'WHOLEFDS', 100, merchant='Whole Foods'),
+            txn('2025-01-20', 'WHOLEFDS', 100, merchant='Whole Foods'),
+            txn('2025-02-05', 'WHOLEFDS', 300, merchant='Whole Foods'),
+            txn('2025-01-10', 'AMZN', 50, merchant='Amazon',
+                category='Shopping', subcategory='Online'),
+            txn('2025-02-10', 'AMZN', 50, merchant='Amazon',
+                category='Shopping', subcategory='Online'),
+        ])
+
+    def test_category_actual_is_a_monthly_average(self, two_month_stats):
+        budgets = parse_budgets({'budgets': {'Food': 200}})
+        result, = evaluate_budgets(budgets, two_month_stats)
+        # 500 of food across 2 months
+        assert result.actual_total == 500
+        assert result.actual_monthly_avg == 250
+        assert result.status == 'over'
+        assert result.variance == 50
+
+    def test_months_over_counts_individual_months(self, two_month_stats):
+        budgets = parse_budgets({'budgets': {'Food': 250}})
+        result, = evaluate_budgets(budgets, two_month_stats)
+        # Jan is 200 (under target), Feb is 300 (over target)
+        assert result.actual_by_month == {'2025-01': 200, '2025-02': 300}
+        assert result.months_over == 1
+
+    def test_total_scope_covers_every_category(self, two_month_stats):
+        budgets = parse_budgets({'budgets': {'total': 1000}})
+        result, = evaluate_budgets(budgets, two_month_stats)
+        assert result.actual_total == 600
+
+    def test_subcategory_scope_is_narrower_than_category(self, two_month_stats):
+        budgets = parse_budgets({'budgets': {'Food/Grocery': 100, 'Food/Dining': 100}})
+        grocery = next(r for r in evaluate_budgets(budgets, two_month_stats)
+                       if r.budget.subcategory == 'Grocery')
+        dining = next(r for r in evaluate_budgets(budgets, two_month_stats)
+                      if r.budget.subcategory == 'Dining')
+        assert grocery.actual_total == 500
+        assert dining.actual_total == 0
+
+    def test_yearly_budget_compares_against_the_running_total(self):
+        stats = stats_for([
+            txn('2025-01-05', 'AIRLINE', 1000, merchant='Airline', category='Travel'),
+            txn('2025-02-05', 'HOTEL', 500, merchant='Hotel', category='Travel'),
+        ])
+        budgets = parse_budgets({'budgets': {'Travel': {'amount': 2000, 'period': 'yearly'}}})
+        result, = evaluate_budgets(budgets, stats)
+        assert result.comparison_actual == 1500
+        assert result.status == 'under'
+        assert result.pct_used == pytest.approx(75.0)
+
+    def test_income_and_transfers_never_count_as_spending(self):
+        stats = stats_for([
+            txn('2025-01-01', 'PAYCHECK', -5000, merchant='Salary',
+                category='Income', tags=['income']),
+            txn('2025-01-02', 'XFER', 1000, merchant='Savings',
+                category='Transfers', tags=['transfer']),
+            txn('2025-01-03', '401K', 500, merchant='401k',
+                category='Transfers', tags=['investment']),
+            txn('2025-01-04', 'WHOLEFDS', 100, merchant='Whole Foods'),
+        ])
+        budgets = parse_budgets({'budgets': {'total': 1000}})
+        result, = evaluate_budgets(budgets, stats)
+        assert result.actual_total == 100
+
+    def test_refunds_reduce_the_month_they_land_in(self):
+        stats = stats_for([
+            txn('2025-01-05', 'AMZN', 200, merchant='Amazon', category='Shopping'),
+            txn('2025-01-20', 'AMZN REFUND', -50, merchant='Amazon', category='Shopping'),
+        ])
+        budgets = parse_budgets({'budgets': {'Shopping': 100}})
+        result, = evaluate_budgets(budgets, stats)
+        assert result.actual_total == 150
+
+    def test_status_thresholds(self):
+        stats = stats_for([txn('2025-01-05', 'WHOLEFDS', 95, merchant='Whole Foods')])
+        under, = evaluate_budgets(parse_budgets({'budgets': {'Food': 200}}), stats)
+        near, = evaluate_budgets(parse_budgets({'budgets': {'Food': 100}}), stats)
+        over, = evaluate_budgets(parse_budgets({'budgets': {'Food': 50}}), stats)
+        assert (under.status, near.status, over.status) == ('under', 'near', 'over')
+
+    def test_zero_target_is_breached_by_any_spending(self):
+        """'Food: 0' means spend nothing, so $100 is over budget, not 0% used."""
+        stats = stats_for([txn('2025-01-05', 'WHOLEFDS', 100, merchant='Whole Foods')])
+        result, = evaluate_budgets(parse_budgets({'budgets': {'Food': 0}}), stats)
+        assert result.status == 'over'
+        assert result.pct_used == 100.0
+        assert result.months_over == 1
+        assert result.variance == 100
+
+    def test_zero_target_with_no_spending_is_within_budget(self):
+        stats = stats_for([
+            txn('2025-01-05', 'PAYCHECK', -100, merchant='Salary',
+                category='Income', tags=['income']),
+        ])
+        result, = evaluate_budgets(parse_budgets({'budgets': {'total': 0}}), stats)
+        assert result.status == 'under'
+        assert result.pct_used == 0.0
+
+    def test_total_is_never_reported_as_a_typo(self):
+        """'total' names no category, so an empty result is not a misspelling."""
+        stats = stats_for([
+            txn('2025-01-05', 'PAYCHECK', -100, merchant='Salary',
+                category='Income', tags=['income']),
+        ])
+        report = build_budget_report({'budgets': {'total': 500}}, stats)
+        assert report['problems'] == []
+
+    def test_unmatched_budget_is_reported_with_a_suggestion(self):
+        """A silent zero would read as perfect discipline instead of a typo."""
+        stats = stats_for([txn('2025-01-05', 'WHOLEFDS', 100, merchant='Whole Foods')])
+        report = build_budget_report({'budgets': {'Fooood': 200}}, stats)
+        problem, = report['problems']
+        assert problem['key'] == 'Fooood'
+        assert 'Food' in problem['suggestions']
+
+    def test_matched_budget_has_no_problem_entry(self):
+        stats = stats_for([txn('2025-01-05', 'WHOLEFDS', 100, merchant='Whole Foods')])
+        report = build_budget_report({'budgets': {'Food': 200}}, stats)
+        assert report['problems'] == []
+
+    def test_report_is_disabled_without_budgets(self):
+        stats = stats_for([txn('2025-01-05', 'WHOLEFDS', 100, merchant='Whole Foods')])
+        assert build_budget_report({}, stats)['enabled'] is False
+
+
+# =============================================================================
+# Anomaly detection
+# =============================================================================
+
+class TestAnomalies:
+
+    def _kinds(self, report):
+        return {a.kind for a in report['anomalies']}
+
+    def _by_kind(self, report, kind):
+        return [a for a in report['anomalies'] if a.kind == kind]
+
+    def test_single_month_of_data_produces_nothing(self):
+        """With no history there is nothing to compare against."""
+        stats = stats_for([txn('2025-01-05', 'WHOLEFDS', 100, merchant='Whole Foods')])
+        report = detect_anomalies(stats)
+        assert report['enabled'] is False
+        assert report['anomalies'] == []
+
+    def test_price_increase_on_a_recurring_charge(self):
+        stats = stats_for([
+            txn('2025-01-05', 'NETFLIX', 15.99, merchant='Netflix', category='Subscriptions'),
+            txn('2025-02-05', 'NETFLIX', 15.99, merchant='Netflix', category='Subscriptions'),
+            txn('2025-03-05', 'NETFLIX', 15.99, merchant='Netflix', category='Subscriptions'),
+            txn('2025-04-28', 'NETFLIX', 24.99, merchant='Netflix', category='Subscriptions'),
+        ])
+        found, = self._by_kind(detect_anomalies(stats), PRICE_INCREASE)
+        assert found.subject == 'Netflix'
+        assert found.impact == pytest.approx(9.0)
+
+    def test_small_increases_are_ignored(self):
+        stats = stats_for([
+            txn('2025-01-05', 'NETFLIX', 15.99, merchant='Netflix'),
+            txn('2025-02-05', 'NETFLIX', 15.99, merchant='Netflix'),
+            txn('2025-03-05', 'NETFLIX', 15.99, merchant='Netflix'),
+            txn('2025-04-28', 'NETFLIX', 17.99, merchant='Netflix'),
+        ])
+        assert PRICE_INCREASE not in self._kinds(detect_anomalies(stats))
+
+    def test_new_merchant_in_the_latest_month(self):
+        stats = stats_for([
+            txn('2025-01-05', 'WHOLEFDS', 100, merchant='Whole Foods'),
+            txn('2025-02-28', 'WHOLEFDS', 100, merchant='Whole Foods'),
+            txn('2025-02-28', 'NEWGYM', 80, merchant='New Gym', category='Health'),
+        ])
+        found, = self._by_kind(detect_anomalies(stats), NEW_MERCHANT)
+        assert found.subject == 'New Gym'
+
+    def test_trivial_new_merchants_are_ignored(self):
+        stats = stats_for([
+            txn('2025-01-05', 'WHOLEFDS', 100, merchant='Whole Foods'),
+            txn('2025-02-28', 'WHOLEFDS', 100, merchant='Whole Foods'),
+            txn('2025-02-28', 'SNACK', 3, merchant='Snack Bar'),
+        ])
+        assert NEW_MERCHANT not in self._kinds(detect_anomalies(stats))
+
+    def test_missing_recurring_charge_is_flagged(self):
+        stats = stats_for([
+            txn('2025-01-05', 'RENT', 2000, merchant='Rent', category='Housing'),
+            txn('2025-02-05', 'RENT', 2000, merchant='Rent', category='Housing'),
+            txn('2025-03-05', 'RENT', 2000, merchant='Rent', category='Housing'),
+            txn('2025-04-28', 'WHOLEFDS', 50, merchant='Whole Foods'),
+        ])
+        found, = self._by_kind(detect_anomalies(stats), MISSING_RECURRING)
+        assert found.subject == 'Rent'
+        assert found.impact == pytest.approx(2000)
+
+    def test_partial_month_does_not_flag_a_charge_that_is_not_due_yet(self):
+        """Rent billed on the 5th is not 'missing' when data stops on the 3rd."""
+        stats = stats_for([
+            txn('2025-01-25', 'RENT', 2000, merchant='Rent', category='Housing'),
+            txn('2025-02-25', 'RENT', 2000, merchant='Rent', category='Housing'),
+            txn('2025-03-25', 'RENT', 2000, merchant='Rent', category='Housing'),
+            txn('2025-04-03', 'WHOLEFDS', 50, merchant='Whole Foods'),
+        ])
+        report = detect_anomalies(stats)
+        assert report['latest_month_complete'] is False
+        assert MISSING_RECURRING not in self._kinds(report)
+
+    def test_month_end_biller_is_not_missing_before_its_due_date(self):
+        """A day-30 charge is not overdue just because data reached day 28.
+
+        Day 28 makes the month look 'complete' in aggregate, but whether an
+        individual charge is late depends on that merchant's own billing day.
+        """
+        stats = stats_for([
+            txn('2025-01-30', 'RENT', 2000, merchant='Rent', category='Housing'),
+            txn('2025-02-28', 'RENT', 2000, merchant='Rent', category='Housing'),
+            txn('2025-03-30', 'RENT', 2000, merchant='Rent', category='Housing'),
+            txn('2025-04-28', 'WHOLEFDS', 50, merchant='Whole Foods'),
+        ])
+        report = detect_anomalies(stats)
+        assert report['latest_month_complete'] is True
+        assert MISSING_RECURRING not in self._kinds(report)
+
+    def test_month_end_biller_is_still_flagged_once_the_month_runs_out(self):
+        """A day-31 biller must not be suppressed forever in a 30-day month."""
+        stats = stats_for([
+            txn('2025-01-31', 'GYM', 80, merchant='Gym', category='Health'),
+            txn('2025-02-28', 'GYM', 80, merchant='Gym', category='Health'),
+            txn('2025-03-31', 'GYM', 80, merchant='Gym', category='Health'),
+            txn('2025-04-30', 'WHOLEFDS', 50, merchant='Whole Foods'),
+        ])
+        found, = self._by_kind(detect_anomalies(stats), MISSING_RECURRING)
+        assert found.subject == 'Gym'
+
+    def test_early_month_biller_is_still_flagged_when_genuinely_missing(self):
+        stats = stats_for([
+            txn('2025-01-05', 'RENT', 2000, merchant='Rent', category='Housing'),
+            txn('2025-02-05', 'RENT', 2000, merchant='Rent', category='Housing'),
+            txn('2025-03-05', 'RENT', 2000, merchant='Rent', category='Housing'),
+            txn('2025-04-28', 'WHOLEFDS', 50, merchant='Whole Foods'),
+        ])
+        found, = self._by_kind(detect_anomalies(stats), MISSING_RECURRING)
+        assert found.subject == 'Rent'
+
+    def test_category_spike_subject_is_a_category_not_a_merchant(self):
+        """The report filters on this subject, so its scope must be knowable.
+
+        A category_spike names a category; filtering it as a merchant would
+        match nothing and blank the report.
+        """
+        stats = stats_for([
+            txn('2025-01-05', 'WHOLEFDS', 200, merchant='Whole Foods'),
+            txn('2025-02-05', 'WHOLEFDS', 200, merchant='Whole Foods'),
+            txn('2025-03-05', 'WHOLEFDS', 200, merchant='Whole Foods'),
+            txn('2025-04-28', 'WHOLEFDS', 900, merchant='Whole Foods'),
+        ])
+        spike, = self._by_kind(detect_anomalies(stats), CATEGORY_SPIKE)
+        assert spike.subject == 'Food'
+        assert spike.subject not in stats['by_merchant']
+
+    def test_occasional_merchant_is_not_treated_as_missing(self):
+        """Every-other-month shopping is not a cancelled subscription."""
+        stats = stats_for([
+            txn('2025-01-05', 'COSTCO', 200, merchant='Costco', category='Shopping'),
+            txn('2025-03-05', 'COSTCO', 200, merchant='Costco', category='Shopping'),
+            txn('2025-05-05', 'COSTCO', 200, merchant='Costco', category='Shopping'),
+            txn('2025-06-28', 'WHOLEFDS', 50, merchant='Whole Foods'),
+        ])
+        assert MISSING_RECURRING not in self._kinds(detect_anomalies(stats))
+
+    def test_category_spike(self):
+        stats = stats_for([
+            txn('2025-01-05', 'WHOLEFDS', 200, merchant='Whole Foods'),
+            txn('2025-02-05', 'WHOLEFDS', 200, merchant='Whole Foods'),
+            txn('2025-03-05', 'WHOLEFDS', 200, merchant='Whole Foods'),
+            txn('2025-04-28', 'WHOLEFDS', 900, merchant='Whole Foods'),
+        ])
+        assert CATEGORY_SPIKE in self._kinds(detect_anomalies(stats))
+
+    def test_large_transaction_against_a_merchant_norm(self):
+        stats = stats_for([
+            txn('2025-01-05', 'AMZN', 40, merchant='Amazon', category='Shopping'),
+            txn('2025-02-05', 'AMZN', 45, merchant='Amazon', category='Shopping'),
+            txn('2025-03-05', 'AMZN', 50, merchant='Amazon', category='Shopping'),
+            txn('2025-03-18', 'AMZN', 900, merchant='Amazon', category='Shopping'),
+        ])
+        found, = self._by_kind(detect_anomalies(stats), LARGE_TRANSACTION)
+        assert found.subject == 'Amazon'
+        assert found.amount == pytest.approx(900)
+
+    def test_warnings_sort_ahead_of_informational_items(self):
+        stats = stats_for([
+            txn('2025-01-05', 'NETFLIX', 10, merchant='Netflix', category='Subscriptions'),
+            txn('2025-02-05', 'NETFLIX', 10, merchant='Netflix', category='Subscriptions'),
+            txn('2025-03-05', 'NETFLIX', 10, merchant='Netflix', category='Subscriptions'),
+            txn('2025-04-28', 'NETFLIX', 40, merchant='Netflix', category='Subscriptions'),
+            txn('2025-04-28', 'NEWSHOP', 500, merchant='New Shop', category='Shopping'),
+        ])
+        severities = [a.severity for a in detect_anomalies(stats)['anomalies']]
+        assert severities == sorted(severities, key=lambda s: s != 'warn')
+
+    def test_currency_formatter_is_used_in_detail_text(self):
+        stats = stats_for([
+            txn('2025-01-05', 'NETFLIX', 10, merchant='Netflix'),
+            txn('2025-02-05', 'NETFLIX', 10, merchant='Netflix'),
+            txn('2025-03-05', 'NETFLIX', 10, merchant='Netflix'),
+            txn('2025-04-28', 'NETFLIX', 40, merchant='Netflix'),
+        ])
+        report = detect_anomalies(stats, fmt=lambda v: f"{v:,.2f} zl")
+        assert 'zl' in report['anomalies'][0].detail
+
+    def test_limit_caps_the_list_but_reports_the_true_count(self):
+        transactions = []
+        for i in range(20):
+            name = f"Shop {i}"
+            for month in ('01', '02', '03'):
+                transactions.append(txn(f'2025-{month}-05', name, 10, merchant=name,
+                                        category='Shopping'))
+            transactions.append(txn('2025-04-28', name, 100, merchant=name,
+                                    category='Shopping'))
+        report = detect_anomalies(stats_for(transactions), limit=5)
+        assert len(report['anomalies']) == 5
+        assert report['total_found'] > 5
+
+
+# =============================================================================
+# Duplicate detection
+# =============================================================================
+
+class TestDuplicates:
+
+    def test_normalize_description_ignores_punctuation_and_case(self):
+        assert normalize_description('SQ *Coffee-Shop') == normalize_description('sq coffee shop')
+
+    def test_clean_data_reports_nothing(self):
+        groups = find_duplicates([
+            txn('2025-01-05', 'WHOLEFDS', 100),
+            txn('2025-01-06', 'WHOLEFDS', 100),
+        ])
+        assert groups == []
+
+    def test_same_amount_and_description_on_different_days_is_not_a_duplicate(self):
+        groups = find_duplicates([
+            txn('2025-01-05', 'NETFLIX', 15.99),
+            txn('2025-02-05', 'NETFLIX', 15.99),
+        ])
+        assert groups == []
+
+    def test_overlapping_exports_are_cross_file(self):
+        groups = find_duplicates([
+            txn('2025-01-05', 'WHOLEFDS', 100, source_file='jan.csv'),
+            txn('2025-01-05', 'WHOLEFDS', 100, source_file='q1.csv'),
+        ])
+        group, = groups
+        assert group.kind == CROSS_FILE
+        assert group.count == 2
+        assert group.impact == 100
+        assert sorted(group.files) == ['jan.csv', 'q1.csv']
+
+    def test_repeats_inside_one_file_are_reported_separately(self):
+        """Two identical coffees on one day are usually real."""
+        groups = find_duplicates([
+            txn('2025-01-05', 'STARBUCKS', 5, source_file='jan.csv'),
+            txn('2025-01-05', 'STARBUCKS', 5, source_file='jan.csv'),
+        ])
+        group, = groups
+        assert group.kind == SAME_FILE
+
+    def test_report_splits_kinds_and_totals_the_impact(self):
+        report = build_duplicate_report([
+            txn('2025-01-05', 'WHOLEFDS', 100, source_file='jan.csv'),
+            txn('2025-01-05', 'WHOLEFDS', 100, source_file='q1.csv'),
+            txn('2025-01-06', 'STARBUCKS', 5, source_file='jan.csv'),
+            txn('2025-01-06', 'STARBUCKS', 5, source_file='jan.csv'),
+        ])
+        assert len(report['cross_file']) == 1
+        assert len(report['same_file']) == 1
+        assert report['cross_file_impact'] == 100
+        assert report['same_file_impact'] == 5
+        assert report['total_count'] == 2
+
+    def test_three_copies_count_two_extras(self):
+        report = build_duplicate_report([
+            txn('2025-01-05', 'WHOLEFDS', 100, source_file=f'{n}.csv') for n in 'abc'
+        ])
+        group, = report['cross_file']
+        assert group.count == 3
+        assert group.impact == 200
+
+    def test_detection_can_be_disabled(self):
+        report = build_duplicate_report([
+            txn('2025-01-05', 'WHOLEFDS', 100, source_file='jan.csv'),
+            txn('2025-01-05', 'WHOLEFDS', 100, source_file='q1.csv'),
+        ], enabled=False)
+        assert report['enabled'] is False
+        assert report['cross_file'] == []
+
+
+# =============================================================================
+# End-to-end wiring through the CLI
+# =============================================================================
+
+def _write_budget_project(tmp_path, extra_settings='', second_export=False):
+    config_dir = tmp_path / 'config'
+    data_dir = tmp_path / 'data'
+    config_dir.mkdir()
+    data_dir.mkdir()
+
+    rows = [
+        '01/05/2025,WHOLEFDS MKT,200.00',
+        '02/05/2025,WHOLEFDS MKT,200.00',
+        '03/05/2025,WHOLEFDS MKT,200.00',
+        '04/28/2025,WHOLEFDS MKT,600.00',
+    ]
+    (data_dir / 'card.csv').write_text('Date,Description,Amount\n' + '\n'.join(rows) + '\n')
+
+    sources = """  - name: Card
+    file: data/card.csv
+    format: "{date:%m/%d/%Y},{description},{amount}"
+    has_header: true
+"""
+    if second_export:
+        (data_dir / 'card-again.csv').write_text(
+            'Date,Description,Amount\n' + rows[0] + '\n')
+        sources += """  - name: Card Re-export
+    file: data/card-again.csv
+    format: "{date:%m/%d/%Y},{description},{amount}"
+    has_header: true
+"""
+
+    (config_dir / 'settings.yaml').write_text(
+        f"title: Test\n\ndata_sources:\n{sources}\n"
+        f"merchants_file: config/merchants.rules\n{extra_settings}"
+    )
+    (config_dir / 'merchants.rules').write_text(
+        '[Whole Foods]\nmatch: contains("WHOLEFDS")\ncategory: Food\nsubcategory: Grocery\n'
+    )
+    return config_dir
+
+
+def run_tally(*args):
+    return subprocess.run(['uv', 'run', 'tally', *args],
+                          capture_output=True, text=True, cwd=REPO_ROOT)
+
+
+class TestCliIntegration:
+
+    def test_budgets_appear_in_the_summary(self, tmp_path):
+        config_dir = _write_budget_project(tmp_path, 'budgets:\n  Food: 250\n')
+        result = run_tally('up', '--config', str(config_dir), '--format', 'summary')
+        assert result.returncode == 0, result.stderr
+        assert 'BUDGETS' in result.stdout
+        assert 'over budget' in result.stdout
+
+    def test_budgets_appear_in_json(self, tmp_path):
+        config_dir = _write_budget_project(tmp_path, 'budgets:\n  Food: 250\n')
+        result = run_tally('up', '--config', str(config_dir), '--format', 'json')
+        assert result.returncode == 0, result.stderr
+        payload = json.loads(result.stdout)
+        target, = payload['budgets']['targets']
+        assert target['label'] == 'Food'
+        assert target['target'] == 250
+        assert target['status'] == 'over'
+
+    def test_no_budget_block_means_no_budget_output(self, tmp_path):
+        config_dir = _write_budget_project(tmp_path)
+        result = run_tally('up', '--config', str(config_dir), '--format', 'json')
+        assert result.returncode == 0, result.stderr
+        assert 'budgets' not in json.loads(result.stdout)
+
+    def test_malformed_budget_block_fails_with_guidance(self, tmp_path):
+        config_dir = _write_budget_project(tmp_path, 'budgets:\n  Food: not-a-number\n')
+        result = run_tally('up', '--config', str(config_dir), '--format', 'summary')
+        assert result.returncode == 1
+        assert 'must be a number' in result.stderr
+        assert 'tally diag' in result.stderr
+
+    def test_overlapping_exports_warn(self, tmp_path):
+        config_dir = _write_budget_project(tmp_path, second_export=True)
+        result = run_tally('up', '--config', str(config_dir), '--format', 'summary')
+        assert result.returncode == 0, result.stderr
+        assert 'appear in more than one file' in result.stdout
+
+    def test_duplicate_check_can_be_turned_off(self, tmp_path):
+        config_dir = _write_budget_project(tmp_path, 'duplicate_check: false\n',
+                                           second_export=True)
+        result = run_tally('up', '--config', str(config_dir), '--format', 'summary')
+        assert result.returncode == 0, result.stderr
+        assert 'appear in more than one file' not in result.stdout
+
+    def test_output_directory_is_created(self, tmp_path):
+        """A missing --output directory used to raise a raw FileNotFoundError."""
+        config_dir = _write_budget_project(tmp_path)
+        target = tmp_path / 'nested' / 'deeper' / 'report.html'
+        result = run_tally('up', '--config', str(config_dir), '-o', str(target), '--quiet')
+        assert result.returncode == 0, result.stderr
+        assert target.exists()
+
+    def test_output_pointing_at_a_directory_explains_itself(self, tmp_path):
+        config_dir = _write_budget_project(tmp_path)
+        target = tmp_path / 'adirectory'
+        target.mkdir()
+        result = run_tally('up', '--config', str(config_dir), '-o', str(target), '--quiet')
+        assert result.returncode == 1
+        assert 'directory, not a file' in result.stderr
+
+    def test_anomalies_reach_the_markdown_export(self, tmp_path):
+        config_dir = _write_budget_project(tmp_path)
+        result = run_tally('up', '--config', str(config_dir), '--format', 'markdown')
+        assert result.returncode == 0, result.stderr
+        assert 'Worth a Look' in result.stdout
+
+
+# =============================================================================
+# Credits reconciliation (regression)
+# =============================================================================
+
+class TestCreditsReconciliation:
+    """A negative total is not automatically a refund.
+
+    Transfers and income can also net negative; listing them under
+    Credits/Refunds made the rows disagree with the reported total.
+    """
+
+    @pytest.fixture
+    def mixed_stats(self):
+        return stats_for([
+            txn('2025-01-05', 'AMZN', 200, merchant='Amazon', category='Shopping'),
+            txn('2025-01-20', 'AMZN REFUND', -50, merchant='Amazon', category='Shopping'),
+            txn('2025-01-10', 'STOCK SALE', -10000, merchant='Stock Sale',
+                category='Transfers', tags=['transfer']),
+        ])
+
+    def test_transfer_is_not_counted_as_a_credit(self, mixed_stats):
+        assert mixed_stats['by_merchant']['Stock Sale']['credits'] == 0
+        assert mixed_stats['credits_total'] == 50
+
+    def test_merchant_credits_sum_to_the_reported_total(self, mixed_stats):
+        per_merchant = sum(d['credits'] for d in mixed_stats['by_merchant'].values())
+        assert per_merchant == pytest.approx(mixed_stats['credits_total'])
+
+    def test_json_credits_list_matches_the_total(self, mixed_stats):
+        from tally.analyzer import export_json
+        payload = json.loads(export_json(mixed_stats))
+        assert [c['merchant'] for c in payload['credits']] == ['Amazon']
+        assert sum(c['amount'] for c in payload['credits']) == pytest.approx(
+            payload['summary']['credits_total'])

--- a/tests/test_report_html.py
+++ b/tests/test_report_html.py
@@ -2125,3 +2125,199 @@ class TestTransformDirective:
 
         badge = txn_row.locator(".extra-fields-trigger")
         expect(badge).not_to_be_visible()
+
+
+# =============================================================================
+# Review panels: budgets, anomalies, duplicate warnings
+# =============================================================================
+
+@pytest.fixture(scope="module")
+def review_report_path(tmp_path_factory):
+    """A report exercising budgets, anomalies and duplicate detection.
+
+    Whole Foods runs at 200/month then jumps to 600, Netflix rises from 15.99
+    to 24.99, a new merchant appears in the final month, and one export
+    overlaps another so the same transaction is loaded twice.
+    """
+    tmp_dir = tmp_path_factory.mktemp("review_report")
+    config_dir = tmp_dir / "config"
+    data_dir = tmp_dir / "data"
+    output_dir = tmp_dir / "output"
+    for d in (config_dir, data_dir, output_dir):
+        d.mkdir()
+
+    rows = [
+        "01/05/2025,WHOLEFDS MKT,200.00",
+        "02/05/2025,WHOLEFDS MKT,200.00",
+        "03/05/2025,WHOLEFDS MKT,200.00",
+        "04/28/2025,WHOLEFDS MKT,600.00",
+        "01/10/2025,NETFLIX.COM,15.99",
+        "02/10/2025,NETFLIX.COM,15.99",
+        "03/10/2025,NETFLIX.COM,15.99",
+        "04/10/2025,NETFLIX.COM,24.99",
+        "04/20/2025,NEW GYM MEMBERSHIP,120.00",
+    ]
+    (data_dir / "card.csv").write_text("Date,Description,Amount\n" + "\n".join(rows) + "\n")
+    # An overlapping re-export of the first row only.
+    (data_dir / "card-again.csv").write_text("Date,Description,Amount\n" + rows[0] + "\n")
+
+    (config_dir / "settings.yaml").write_text("""title: Review Test
+
+data_sources:
+  - name: Card
+    file: data/card.csv
+    format: "{date:%m/%d/%Y},{description},{amount}"
+    has_header: true
+  - name: Card Re-export
+    file: data/card-again.csv
+    format: "{date:%m/%d/%Y},{description},{amount}"
+    has_header: true
+
+merchants_file: config/merchants.rules
+
+budgets:
+  Food: 250
+  Subscriptions: 100
+  Nonexistent: 50
+""")
+
+    (config_dir / "merchants.rules").write_text("""[Whole Foods]
+match: contains("WHOLEFDS")
+category: Food
+subcategory: Grocery
+
+[Netflix]
+match: contains("NETFLIX")
+category: Subscriptions
+subcategory: Streaming
+
+[New Gym]
+match: contains("NEW GYM")
+category: Health
+subcategory: Fitness
+""")
+
+    report_file = output_dir / "report.html"
+    result = subprocess.run(
+        ["uv", "run", "tally", "up", "-o", str(report_file), "--config", str(config_dir)],
+        capture_output=True,
+        text=True,
+        cwd=os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    )
+    if result.returncode != 0:
+        pytest.fail(f"Failed to generate report: {result.stderr}")
+
+    return str(report_file)
+
+
+class TestBudgetPanel:
+    """Budget targets rendered in the HTML report."""
+
+    def test_budget_section_visible(self, page: Page, review_report_path):
+        page.goto(f"file://{review_report_path}")
+        expect(page.get_by_test_id("budget-section")).to_be_visible()
+
+    def test_one_row_per_budget(self, page: Page, review_report_path):
+        page.goto(f"file://{review_report_path}")
+        expect(page.get_by_test_id("budget-row")).to_have_count(3)
+
+    def test_over_budget_row_is_marked_over(self, page: Page, review_report_path):
+        """Food averages 300/month against a 250 target."""
+        page.goto(f"file://{review_report_path}")
+        food = page.get_by_test_id("budget-row").filter(has_text="Food")
+        expect(food).to_have_class(re.compile(r"\bover\b"))
+        expect(food).to_contain_text("Over budget")
+
+    def test_under_budget_row_is_marked_under(self, page: Page, review_report_path):
+        """Netflix averages well under the 100 subscriptions target."""
+        page.goto(f"file://{review_report_path}")
+        subs = page.get_by_test_id("budget-row").filter(has_text="Subscriptions")
+        expect(subs).to_have_class(re.compile(r"\bunder\b"))
+        expect(subs).to_contain_text("Within budget")
+
+    def test_header_counts_targets_over_budget(self, page: Page, review_report_path):
+        page.goto(f"file://{review_report_path}")
+        expect(page.get_by_test_id("budget-section")).to_contain_text("over budget")
+
+    def test_unmatched_budget_shows_a_suggestion(self, page: Page, review_report_path):
+        page.goto(f"file://{review_report_path}")
+        problem = page.locator(".budget-problem")
+        expect(problem).to_contain_text("Nonexistent")
+        expect(problem).to_contain_text("matched no transactions")
+
+    def test_bar_never_overflows_its_track(self, page: Page, review_report_path):
+        """An over-budget bar is capped at 100% width."""
+        page.goto(f"file://{review_report_path}")
+        widths = page.locator(".budget-bar-fill").evaluate_all(
+            "els => els.map(e => parseFloat(e.style.width))"
+        )
+        assert widths, "expected budget bars to render"
+        assert all(w <= 100 for w in widths)
+
+
+class TestAnomalyPanel:
+    """The 'worth a look' list in the HTML report."""
+
+    def test_anomaly_section_visible(self, page: Page, review_report_path):
+        page.goto(f"file://{review_report_path}")
+        expect(page.get_by_test_id("anomaly-section")).to_be_visible()
+
+    def test_price_increase_is_listed(self, page: Page, review_report_path):
+        page.goto(f"file://{review_report_path}")
+        expect(page.get_by_test_id("anomaly-section")).to_contain_text("Netflix")
+
+    def test_new_merchant_is_listed(self, page: Page, review_report_path):
+        page.goto(f"file://{review_report_path}")
+        expect(page.get_by_test_id("anomaly-section")).to_contain_text("New Gym")
+
+    def test_clicking_an_anomaly_filters_to_that_merchant(self, page: Page, review_report_path):
+        page.goto(f"file://{review_report_path}")
+        page.get_by_test_id("anomaly-row").filter(has_text="Netflix").first.click()
+        expect(page.get_by_test_id("filter-chip")).to_contain_text("Netflix")
+
+    def test_clicking_a_category_spike_filters_by_category(self, page: Page, review_report_path):
+        """A category spike names a category, so it must not filter by merchant.
+
+        Filtering "Food" as a merchant matches nothing and blanks the report.
+        """
+        page.goto(f"file://{review_report_path}")
+        spike = page.get_by_test_id("anomaly-row").filter(has_text="spiked").first
+        expect(spike).to_be_visible()
+        spike.click()
+
+        # The chip is a category filter (c), not a merchant filter (m).
+        chip = page.get_by_test_id("filter-chip")
+        expect(chip).to_contain_text("Food")
+        expect(chip.locator(".chip-type")).to_have_text("c")
+
+        # And the report still shows data rather than filtering everything out.
+        expect(page.get_by_test_id("filtered-amount")).not_to_have_text(
+            re.compile(r"^[^\d]*0([^\d]|$)"))
+
+
+class TestDuplicateBanner:
+    """The duplicate transaction warning in the HTML report."""
+
+    def test_banner_visible_when_exports_overlap(self, page: Page, review_report_path):
+        page.goto(f"file://{review_report_path}")
+        expect(page.get_by_test_id("duplicate-banner")).to_be_visible()
+
+    def test_banner_names_both_files(self, page: Page, review_report_path):
+        page.goto(f"file://{review_report_path}")
+        banner = page.get_by_test_id("duplicate-banner")
+        expect(banner).to_contain_text("card.csv")
+        expect(banner).to_contain_text("card-again.csv")
+
+    def test_banner_can_be_dismissed(self, page: Page, review_report_path):
+        page.goto(f"file://{review_report_path}")
+        page.get_by_test_id("duplicate-dismiss").click()
+        expect(page.get_by_test_id("duplicate-banner")).not_to_be_visible()
+
+    def test_no_banner_when_data_is_clean(self, page: Page, report_path):
+        """The standard fixture has no overlapping exports."""
+        page.goto(f"file://{report_path}")
+        expect(page.get_by_test_id("duplicate-banner")).not_to_be_visible()
+
+    def test_no_budget_panel_without_budgets(self, page: Page, report_path):
+        page.goto(f"file://{report_path}")
+        expect(page.get_by_test_id("budget-section")).not_to_be_visible()

--- a/tests/test_rule_snapshots.py
+++ b/tests/test_rule_snapshots.py
@@ -31,6 +31,13 @@ class TestRuleSnapshots:
     FIXTURE_DIR = Path(__file__).parent / "fixtures" / "rule_snapshot"
     SNAPSHOT_FILE = FIXTURE_DIR / "expected_output.json"
 
+    # Review features (budgets, anomaly detection, duplicate warnings) sit on
+    # top of rule processing rather than inside it, and their thresholds are
+    # expected to be tuned over time. Keeping them out of the snapshot means
+    # this test keeps failing for the reason it exists: a change in how rules
+    # assign merchants, categories, tags or totals.
+    REVIEW_KEYS = ('budgets', 'anomalies', 'duplicates')
+
     def test_rule_processing_stability(self, tmp_path):
         """Verify rule processing produces identical results.
 
@@ -189,9 +196,13 @@ class TestRuleSnapshots:
         - Sort all tag arrays alphabetically
         - Sort by_category by category/subcategory
         - Sort credits by merchant name
+        - Drop review-only sections (see REVIEW_KEYS)
         """
         import copy
         normalized = copy.deepcopy(output)
+
+        for key in self.REVIEW_KEYS:
+            normalized.pop(key, None)
 
         # Sort merchants by name and normalize their internal arrays
         if 'merchants' in normalized:


### PR DESCRIPTION
## Summary

- add optional monthly and yearly budgets by total, category, subcategory, or tag
- surface new merchants, recurring price increases, missing recurring charges, category spikes, and unusually large transactions
- warn about duplicate transactions caused by overlapping exports
- include review data in terminal, JSON, Markdown, and HTML reports
- fix refund classification, output-directory handling, and negative currency formatting
- exclude an incomplete latest month from monthly budget averages so mid-month reviews are not understated

## Testing

- 866 unit and integration tests pass
- 94 Playwright report tests pass
- 960 tests pass in total

## Compatibility

All new settings are optional. Rule matching is unchanged, and the rule snapshot continues to isolate rule-processing behavior.