### PR TITLE
CI Repair

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,6 +22,9 @@ on:
         type: number
         default: 1
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   build:
     strategy:
@@ -38,13 +41,13 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           ref: ${{ inputs.ref || github.ref }}
           fetch-depth: ${{ inputs.fetch_depth }}
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@v8.1.0
 
       - name: Set up Python
         run: uv python install 3.12
@@ -90,7 +93,7 @@ jobs:
           Compress-Archive -Path tally.exe -DestinationPath tally-${{ matrix.platform }}.zip
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: tally-${{ matrix.platform }}-${{ contains(inputs.version, 'dev') && 'dev' || 'rc' }}
           path: dist/tally-${{ matrix.platform }}.zip

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,9 +22,6 @@ on:
         type: number
         default: 1
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
-
 jobs:
   build:
     strategy:

--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches: [main]
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   # Run tests first - gate the build
   tests:
@@ -15,7 +18,7 @@ jobs:
     outputs:
       version: ${{ steps.version.outputs.version }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - id: version
@@ -54,11 +57,11 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       # Download dev artifacts
       - name: Download dev artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: dev-artifacts
           pattern: tally-*-dev
@@ -66,7 +69,7 @@ jobs:
 
       # Download RC artifacts
       - name: Download RC artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: rc-artifacts
           pattern: tally-*-rc

--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -4,9 +4,6 @@ on:
   push:
     branches: [main]
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
-
 jobs:
   # Run tests first - gate the build
   tests:

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install tally (Unix)
         if: runner.os != 'Windows'

--- a/.github/workflows/generate-release-notes.yml
+++ b/.github/workflows/generate-release-notes.yml
@@ -27,7 +27,7 @@ jobs:
       notes: ${{ steps.output.outputs.notes }}
       generated: ${{ steps.output.outputs.generated }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -24,9 +24,9 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - uses: actions/checkout@v5
-      - uses: actions/configure-pages@v4
-      - uses: actions/upload-pages-artifact@v3
+      - uses: actions/configure-pages@v6
+      - uses: actions/upload-pages-artifact@v5
         with:
           path: docs/
-      - uses: actions/deploy-pages@v4
+      - uses: actions/deploy-pages@v5
         id: deployment

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -23,7 +23,7 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: actions/configure-pages@v4
       - uses: actions/upload-pages-artifact@v3
         with:

--- a/.github/workflows/pr-build-comment.yml
+++ b/.github/workflows/pr-build-comment.yml
@@ -2,8 +2,9 @@ name: PR Build Comment
 
 # The privileged half of PR Build. Runs on `workflow_run`, so it has the base
 # repository's token and `pull-requests: write` - and therefore never checks
-# out, builds, or executes any PR code. Its only inputs are two small values
-# read out of an artifact, and both are validated before use.
+# out, builds, or executes any PR code. Its only input is a PR number read out
+# of an artifact, and that number is both shape-checked and proven to belong to
+# the run that triggered this workflow before any write happens.
 
 on:
   workflow_run:
@@ -32,26 +33,38 @@ jobs:
           run-id: ${{ github.event.workflow_run.id }}
           github-token: ${{ github.token }}
 
-      - name: Read and validate PR metadata
+      - name: Read and verify PR metadata
         id: meta
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RUN_EVENT: ${{ github.event.workflow_run.event }}
+          TRUSTED_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          REPO: ${{ github.repository }}
         run: |
           PR_NUMBER=$(cat pr-meta/pr_number)
-          SHORT_SHA=$(cat pr-meta/short_sha)
 
-          # This artifact was produced by a run over untrusted PR code, so treat
-          # its contents as untrusted input: accept only the exact shapes we
-          # expect, and never interpolate them into a shell or API call unchecked.
+          # `pull_request` resolves workflow files from the PR head, so a fork
+          # controls what its own run writes here. Shape-check first, so the
+          # value is safe to put in an API path at all.
           if ! [[ "$PR_NUMBER" =~ ^[0-9]+$ ]]; then
             echo "Refusing malformed pr_number: $PR_NUMBER"
             exit 1
           fi
-          if ! [[ "$SHORT_SHA" =~ ^[0-9a-f]{7}$ ]]; then
-            echo "Refusing malformed short_sha: $SHORT_SHA"
+
+          # Shape is not ownership: a fork could write someone else's PR number
+          # and steer this privileged run at an unrelated PR. Ask the API what
+          # that PR's head actually is, and require it to match the head SHA
+          # GitHub itself recorded for the triggering run.
+          PR_HEAD_SHA=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}" --jq '.head.sha')
+
+          if [ "$RUN_EVENT" = "pull_request" ] && [ "$PR_HEAD_SHA" != "$TRUSTED_HEAD_SHA" ]; then
+            echo "Refusing pr_number ${PR_NUMBER}: head ${PR_HEAD_SHA} does not match triggering run ${TRUSTED_HEAD_SHA}"
             exit 1
           fi
 
+          # Derived from the API, never from the artifact.
           echo "pr_number=$PR_NUMBER" >> $GITHUB_OUTPUT
-          echo "short_sha=$SHORT_SHA" >> $GITHUB_OUTPUT
+          echo "short_sha=${PR_HEAD_SHA:0:7}" >> $GITHUB_OUTPUT
 
       - name: Build comment body
         run: |
@@ -96,7 +109,7 @@ jobs:
           cat comment.md
 
       - name: Find existing comment
-        uses: peter-evans/find-comment@v3
+        uses: peter-evans/find-comment@v4
         id: find
         with:
           issue-number: ${{ steps.meta.outputs.pr_number }}
@@ -104,7 +117,7 @@ jobs:
           body-includes: '## PR Build Available'
 
       - name: Create or update comment
-        uses: peter-evans/create-or-update-comment@v4
+        uses: peter-evans/create-or-update-comment@v5
         with:
           comment-id: ${{ steps.find.outputs.comment-id }}
           issue-number: ${{ steps.meta.outputs.pr_number }}

--- a/.github/workflows/pr-build-comment.yml
+++ b/.github/workflows/pr-build-comment.yml
@@ -1,0 +1,112 @@
+name: PR Build Comment
+
+# The privileged half of PR Build. Runs on `workflow_run`, so it has the base
+# repository's token and `pull-requests: write` - and therefore never checks
+# out, builds, or executes any PR code. Its only inputs are two small values
+# read out of an artifact, and both are validated before use.
+
+on:
+  workflow_run:
+    workflows: ["PR Build"]
+    types: [completed]
+
+permissions:
+  contents: read
+  actions: read
+  pull-requests: write
+
+jobs:
+  comment:
+    if: >-
+      github.event.workflow_run.conclusion == 'success' &&
+      (github.event.workflow_run.event == 'pull_request' ||
+       github.event.workflow_run.event == 'workflow_dispatch')
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Download PR metadata
+        uses: actions/download-artifact@v8
+        with:
+          name: pr-meta
+          path: pr-meta
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ github.token }}
+
+      - name: Read and validate PR metadata
+        id: meta
+        run: |
+          PR_NUMBER=$(cat pr-meta/pr_number)
+          SHORT_SHA=$(cat pr-meta/short_sha)
+
+          # This artifact was produced by a run over untrusted PR code, so treat
+          # its contents as untrusted input: accept only the exact shapes we
+          # expect, and never interpolate them into a shell or API call unchecked.
+          if ! [[ "$PR_NUMBER" =~ ^[0-9]+$ ]]; then
+            echo "Refusing malformed pr_number: $PR_NUMBER"
+            exit 1
+          fi
+          if ! [[ "$SHORT_SHA" =~ ^[0-9a-f]{7}$ ]]; then
+            echo "Refusing malformed short_sha: $SHORT_SHA"
+            exit 1
+          fi
+
+          echo "pr_number=$PR_NUMBER" >> $GITHUB_OUTPUT
+          echo "short_sha=$SHORT_SHA" >> $GITHUB_OUTPUT
+
+      - name: Build comment body
+        run: |
+          PR_NUMBER="${{ steps.meta.outputs.pr_number }}"
+          RUN_ID="${{ github.event.workflow_run.id }}"
+          SHORT_SHA="${{ steps.meta.outputs.short_sha }}"
+
+          cat > comment.md << 'EOF'
+          ## PR Build Available
+
+          Version: `0.0.PR_NUMBER-SHORT_SHA`
+
+          ### Install from this PR
+
+          **Linux / macOS:**
+          ```bash
+          curl -fsSL https://raw.githubusercontent.com/REPO/main/docs/install-pr.sh | bash -s -- PR_NUMBER
+          ```
+
+          **Windows PowerShell:**
+          ```powershell
+          iex "& { $(irm https://raw.githubusercontent.com/REPO/main/docs/install-pr.ps1) } PR_NUMBER"
+          ```
+
+          **Manual download:** [View workflow run](https://github.com/REPO/actions/runs/RUN_ID) and download artifacts.
+
+          <details>
+          <summary>Requirements</summary>
+
+          - GitHub CLI (`gh`) must be installed and authenticated
+          - Run `gh auth login` if not already authenticated
+
+          </details>
+          EOF
+
+          # Replace placeholders
+          sed -i "s/PR_NUMBER/${PR_NUMBER}/g" comment.md
+          sed -i "s/SHORT_SHA/${SHORT_SHA}/g" comment.md
+          sed -i "s|REPO|${{ github.repository }}|g" comment.md
+          sed -i "s/RUN_ID/${RUN_ID}/g" comment.md
+
+          cat comment.md
+
+      - name: Find existing comment
+        uses: peter-evans/find-comment@v3
+        id: find
+        with:
+          issue-number: ${{ steps.meta.outputs.pr_number }}
+          comment-author: 'github-actions[bot]'
+          body-includes: '## PR Build Available'
+
+      - name: Create or update comment
+        uses: peter-evans/create-or-update-comment@v4
+        with:
+          comment-id: ${{ steps.find.outputs.comment-id }}
+          issue-number: ${{ steps.meta.outputs.pr_number }}
+          body-path: comment.md
+          edit-mode: replace

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -50,13 +50,15 @@ jobs:
           GH_TOKEN: ${{ github.token }}
 
       # Handed to pr-build-comment.yml, which cannot see this run's outputs.
-      # For a fork PR the workflow_run event's `pull_requests` array is empty,
-      # so the PR number has to travel as an artifact.
+      # For a fork PR the workflow_run event's `pull_requests` array is empty
+      # and the commit is not associated with the PR from the base repo's side,
+      # so the PR number has to travel as an artifact. It is not trusted on
+      # arrival - pr-build-comment.yml verifies it against the head SHA GitHub
+      # recorded for this run before using its write token.
       - name: Save PR metadata
         run: |
           mkdir -p pr-meta
           echo "${{ steps.pr.outputs.number }}" > pr-meta/pr_number
-          echo "${{ steps.pr.outputs.short_sha }}" > pr-meta/short_sha
 
       - name: Upload PR metadata
         uses: actions/upload-artifact@v7

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -1,7 +1,13 @@
 name: PR Build
 
+# Builds PR code, including code from forks. Runs under `pull_request`, so it
+# gets a read-only token and no secrets - `actions/checkout` refuses to check
+# out fork code under `pull_request_target`, and rightly so. Posting the result
+# needs write access, which this workflow deliberately does not have; that half
+# lives in pr-build-comment.yml, triggered by `workflow_run`.
+
 on:
-  pull_request_target:
+  pull_request:
     branches: [main]
   workflow_dispatch:
     inputs:
@@ -9,6 +15,9 @@ on:
         description: 'PR number to build'
         required: true
         type: number
+
+permissions:
+  contents: read
 
 jobs:
   prepare:
@@ -40,6 +49,21 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
 
+      # Handed to pr-build-comment.yml, which cannot see this run's outputs.
+      # For a fork PR the workflow_run event's `pull_requests` array is empty,
+      # so the PR number has to travel as an artifact.
+      - name: Save PR metadata
+        run: |
+          mkdir -p pr-meta
+          echo "${{ steps.pr.outputs.number }}" > pr-meta/pr_number
+          echo "${{ steps.pr.outputs.short_sha }}" > pr-meta/short_sha
+
+      - name: Upload PR metadata
+        uses: actions/upload-artifact@v7
+        with:
+          name: pr-meta
+          path: pr-meta/
+
   build:
     needs: prepare
     uses: ./.github/workflows/build.yml
@@ -47,68 +71,3 @@ jobs:
       version: ${{ needs.prepare.outputs.version }}
       git_sha: ${{ needs.prepare.outputs.head_sha }}
       ref: ${{ needs.prepare.outputs.head_sha }}
-
-  comment:
-    needs: [prepare, build]
-    runs-on: ubuntu-latest
-    permissions:
-      pull-requests: write
-
-    steps:
-      - name: Build comment body
-        run: |
-          PR_NUMBER="${{ needs.prepare.outputs.pr_number }}"
-          RUN_ID="${{ github.run_id }}"
-          SHORT_SHA="${{ needs.prepare.outputs.short_sha }}"
-
-          cat > comment.md << 'EOF'
-          ## PR Build Available
-
-          Version: `0.0.PR_NUMBER-SHORT_SHA`
-
-          ### Install from this PR
-
-          **Linux / macOS:**
-          ```bash
-          curl -fsSL https://raw.githubusercontent.com/REPO/main/docs/install-pr.sh | bash -s -- PR_NUMBER
-          ```
-
-          **Windows PowerShell:**
-          ```powershell
-          iex "& { $(irm https://raw.githubusercontent.com/REPO/main/docs/install-pr.ps1) } PR_NUMBER"
-          ```
-
-          **Manual download:** [View workflow run](https://github.com/REPO/actions/runs/RUN_ID) and download artifacts.
-
-          <details>
-          <summary>Requirements</summary>
-
-          - GitHub CLI (`gh`) must be installed and authenticated
-          - Run `gh auth login` if not already authenticated
-
-          </details>
-          EOF
-
-          # Replace placeholders
-          sed -i "s/PR_NUMBER/${PR_NUMBER}/g" comment.md
-          sed -i "s/SHORT_SHA/${SHORT_SHA}/g" comment.md
-          sed -i "s|REPO|${{ github.repository }}|g" comment.md
-          sed -i "s/RUN_ID/${RUN_ID}/g" comment.md
-
-          cat comment.md
-
-      - name: Find existing comment
-        uses: peter-evans/find-comment@v3
-        id: find
-        with:
-          issue-number: ${{ needs.prepare.outputs.pr_number }}
-          comment-author: 'github-actions[bot]'
-          body-includes: '## PR Build Available'
-
-      - name: Create or update comment
-        uses: peter-evans/create-or-update-comment@v4
-        with:
-          comment-id: ${{ steps.find.outputs.comment-id }}
-          issue-number: ${{ needs.prepare.outputs.pr_number }}
-          body-path: comment.md
-          edit-mode: replace

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
       - name: Checkout (for gh CLI context)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Find latest draft release
         id: draft

--- a/.github/workflows/test-install.yml
+++ b/.github/workflows/test-install.yml
@@ -27,7 +27,7 @@ jobs:
     name: ${{ matrix.name }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Run install script
         run: bash docs/install.sh
@@ -42,7 +42,7 @@ jobs:
     name: Windows
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Run install script
         shell: pwsh

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,9 @@ on:
   pull_request:
     branches: [main]
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   # Unit tests run on both platforms (fast, no browser needed)
   unit-tests:
@@ -16,10 +19,10 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@v8.1.0
 
       - name: Set up Python 3.12
         run: uv python install 3.12
@@ -35,10 +38,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@v8.1.0
 
       - name: Set up Python 3.12
         run: uv python install 3.12

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,9 +7,6 @@ on:
   pull_request:
     branches: [main]
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
-
 jobs:
   # Unit tests run on both platforms (fast, no browser needed)
   unit-tests:


### PR DESCRIPTION
> **Independent — based directly on `main`.** Touches `.github/workflows/` only and shares no file with any of my other open PRs, so it can be merged in any order.
> **Diff:** [`main...feature/ci-repair`](https://github.com/terryaney/OpenSource.tally/compare/main...feature/ci-repair)

`PR Build` has failed on **every fork pull request** since 2026-07-20, including ones that change nothing but documentation. This PR fixes that, and separately brings the workflow action pins onto Node 24 ahead of Node 20's removal this fall.

## The break

```
##[error]Refusing to check out fork pull request code from a 'pull_request_target'
workflow. This workflow runs with the base repository's GITHUB_TOKEN, secrets,
default-branch cache scope, and runner access. Fetching and executing a fork's
code in that trusted context commonly leads to "pwn request" vulnerabilities.
```

Nothing in this repository changed. Two things changed underneath it, between two runs 42 hours apart:

| | 2026-07-19 04:13 — passing | 2026-07-20 22:11 — failing |
|---|---|---|
| Runner | `2.335.1` | `2.336.0` |
| `actions/checkout@v4` resolved to | `34e1148…` | `11d5960…` |

`v4` is a moving tag, and the release it now points at refuses to check out fork code under `pull_request_target`. `pr-build.yml` did exactly that — `pull_request_target` plus an explicit `ref:` pointing at the fork's head SHA.

It isn't specific to one contributor: the most recent failure at time of writing is on `sutharion-studious-meme`, and the last green run was on a branch of mine that would fail identically today.

**Bumping to `actions/checkout@v5` does not fix this.** v5 carries the same guard. The pattern itself has to change.

## The fix — split the trusted half from the untrusted half

The problem with `pull_request_target` here is that one workflow both **executes fork code** and **holds a write token**. Those are separated:

| Workflow | Trigger | Token | Touches PR code? |
|---|---|---|---|
| `pr-build.yml` | `pull_request` | `contents: read`, no secrets | yes — builds it |
| `pr-build-comment.yml` *(new)* | `workflow_run` | `pull-requests: write` | **never** |

`pr-build.yml` keeps its `prepare` and `build` jobs and loses the `comment` job. `build.yml` needed no changes at all — under `pull_request`, checking out the head SHA is allowed.

`pr-build-comment.yml` waits for `PR Build` to complete, then posts the same install comment as before.

### Passing the PR number across

The `workflow_run` event's `pull_requests` array is empty for fork PRs, and `GET /repos/{repo}/commits/{sha}/pulls` does not associate fork-originated commits back to the PR from the base repository's side — I checked both against this repo's open PRs, and both come back empty for every fork PR while the commit itself is reachable. So the PR number cannot be recovered from the trusted side alone. It travels as a small artifact written by `prepare`.

That artifact is produced by a run over untrusted code. Under `pull_request`, GitHub resolves workflow files from the PR head, which means a fork controls what its own run writes into that artifact — including writing *someone else's* PR number to aim this privileged workflow at an unrelated PR. Shape validation alone does not prevent that, so the number is checked for **ownership**, not just format:

```bash
# Shape first, so the value is safe to put in an API path at all.
if ! [[ "$PR_NUMBER" =~ ^[0-9]+$ ]]; then exit 1; fi

# Then ownership: ask the API what that PR's head actually is, and require it
# to match the head SHA GitHub itself recorded for the triggering run.
PR_HEAD_SHA=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}" --jq '.head.sha')
if [ "$RUN_EVENT" = "pull_request" ] && [ "$PR_HEAD_SHA" != "$TRUSTED_HEAD_SHA" ]; then
  exit 1
fi
```

`github.event.workflow_run.head_sha` is populated by GitHub from its own record of the triggering run, so a fork cannot forge it. A fork can claim PR #42, but it cannot make #42's head commit equal its own. `short_sha` is then derived from the API response rather than read from the artifact, so the artifact's only remaining role is supplying a number that must survive that check.

The check is skipped for `workflow_dispatch`, where `head_sha` is the dispatched branch rather than a PR head; that path can only be triggered by someone with write access, running the base repository's own copy of the workflow file.

Artifact poisoning is the one remaining attack surface in this pattern, and this is where it gets closed.

### Three things to expect

- **The comment won't post on this PR.** `workflow_run` only fires from the workflow file on the repository's default branch, so `pr-build-comment.yml` starts working once this is merged to `main`. The build half will go green here; the comment half is untestable from a PR by design.
- **There will be a red `PR Build` on this PR, from `main`'s copy of the workflow.** Until this merges, `main` still defines `PR Build` as `pull_request_target`, so every push here starts *two* runs against the same commit: the old one from `main` (which fails at checkout, exactly as described above) and the new one from this branch (which passes). Compare the `event` on each run before reading the result — the failing one is the bug this PR fixes, still firing from the base branch.
- **`pull_request` resolves workflow files from the PR head**, unlike `pull_request_target`. A useful side effect: from now on, CI changes can be validated by the PR that makes them.

## Also: Node 24 action pins

Separate commit, separate problem — Node 20 is being removed from the Actions runner this fall. Node 24 has already been the runner default since 2026-06-16, so nothing fails today; what breaks at removal is any action still declaring `using: node20` in its own metadata. The fix is version bumps, not a runtime override:

| Action | Was | Now |
|---|---|---|
| `actions/checkout` | `v4` | `v5` |
| `actions/upload-artifact` | `v4` | `v7` |
| `actions/download-artifact` | `v4` | `v8` |
| `astral-sh/setup-uv` | `v4` | `v8.1.0` |
| `actions/configure-pages` | `v4` | `v6` |
| `actions/upload-pages-artifact` | `v3` | `v5` |
| `actions/deploy-pages` | `v4` | `v5` |
| `peter-evans/find-comment` | `v3` | `v4` |
| `peter-evans/create-or-update-comment` | `v4` | `v5` |

Every JavaScript action pinned in `.github/workflows` now declares `node24`; the two remaining composites resolve to `node24` internals (`upload-pages-artifact@v5` pins `upload-artifact@v7.0.0`).

Two of these majors carry breaking changes that were checked against this repository before bumping:

- `configure-pages@v5` dropped Next.js < 13.3.0 support under the `static_site_generator` input — not used here, the step takes no inputs.
- `upload-pages-artifact@v4` stopped including dotfiles in the artifact — `docs/` contains none, so nothing is dropped. (`v5` adds an `include-hidden-files` input if that ever changes.)

`FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` was an earlier attempt at this half and has been removed. It was a pre-flip opt-in, it is inert now that Node 24 is the default, and per [actions/runner#4295](https://github.com/actions/runner/issues/4295) it does not even suppress the deprecation annotation.

## Scope

`.github/workflows/` only — ten files, no source, no tests, no documentation.

## Also in flight (independent of this PR)

A separate stack of feature work, each branch based on the one above it. None of it touches `.github/`, so this PR neither blocks nor is blocked by any of them:

1. [#98](https://github.com/davidfowl/tally/pull/98) — glob pattern docs, examples, and CLI tests — [incremental diff](https://github.com/terryaney/OpenSource.tally/compare/main...feature/globbing-documentation)
2. [#99](https://github.com/davidfowl/tally/pull/99) — make the report JSON byte-reproducible — [incremental diff](https://github.com/terryaney/OpenSource.tally/compare/feature/globbing-documentation...feature/report-json-determinism)
3. [#100](https://github.com/davidfowl/tally/pull/100) — date filtering, transaction details, per-transaction tag classification — [incremental diff](https://github.com/terryaney/OpenSource.tally/compare/feature/report-json-determinism...feature/ui-tweaks)
4. [#101](https://github.com/davidfowl/tally/pull/101) — reimagined chart layout, KPI tiles, chart docs — [incremental diff](https://github.com/terryaney/OpenSource.tally/compare/feature/ui-tweaks...feature/charts-reimagined)
5. [#102](https://github.com/davidfowl/tally/pull/102) — composite merchant identity so one merchant can carry multiple categorizations — [incremental diff](https://github.com/terryaney/OpenSource.tally/compare/feature/charts-reimagined...feature/merchant-composite-keys)
6. [#103](https://github.com/davidfowl/tally/pull/103) — categorization review file, `review:` rule flag, `inventory.yaml`

Because the branches are stacked but every PR targets `main`, each one's diff on GitHub includes the PRs above it — #98 is 3 files, #103 is 50. The "incremental diff" links above show just that PR's own contribution, which is the view worth reading them in.
