### PR TITLE
Make report JSON deterministic [2/6]

### DIFF
--- a/config/settings.yaml.example
+++ b/config/settings.yaml.example
@@ -15,10 +15,15 @@ title: "Spending Analysis"
 
 # Data sources - list of transaction files to process
 # Paths are relative to the parent of the config directory
+# Supports glob patterns (*, ?, []) to match multiple files
 data_sources:
   - name: AMEX
-    file: data/amex-2025.csv
+    file: data/amex-2025.csv      # Single file
     type: amex
+  # Example with glob pattern to match multiple files:
+  # - name: AMEX
+  #   file: data/amex*.csv        # Matches amex-2024.csv, amex-2025.csv, etc.
+  #   type: amex
   - name: BOA
     file: data/boa-checking.txt
     type: boa

--- a/docs/formats.html
+++ b/docs/formats.html
@@ -255,7 +255,7 @@
             <tr>
                 <td><code>file</code></td>
                 <td>Yes</td>
-                <td>Path to CSV file (relative or absolute), supports glob patterns (`*`, `?`, `[]`) to match multiple files (files are processed in sorted order)</td>
+                <td>Path to CSV file (relative or absolute), supports glob patterns (<code>*</code>, <code>?</code>, <code>[]</code>) to match multiple files (files are processed in sorted order)</td>
             </tr>
             <tr>
                 <td><code>format</code></td>

--- a/docs/formats.html
+++ b/docs/formats.html
@@ -255,7 +255,7 @@
             <tr>
                 <td><code>file</code></td>
                 <td>Yes</td>
-                <td>Path to CSV file (relative or absolute)</td>
+                <td>Path to CSV file (relative or absolute), supports glob patterns (`*`, `?`, `[]`) to match multiple files (files are processed in sorted order)</td>
             </tr>
             <tr>
                 <td><code>format</code></td>

--- a/src/tally/analyzer.py
+++ b/src/tally/analyzer.py
@@ -363,9 +363,9 @@ def build_merchant_json(merchant_name, data, verbose=0):
     # Add pattern match info if available
     match_info = data.get('match_info')
     if match_info:
-        pattern_tags = match_info.get('tags', [])
-        if isinstance(pattern_tags, set):
-            pattern_tags = sorted(pattern_tags)
+        # Sort unconditionally - tags originate from a set, so a list built from
+        # one carries arbitrary order into the JSON and breaks reproducibility
+        pattern_tags = sorted(match_info.get('tags', []))
         result['pattern'] = {
             'matched': match_info.get('pattern', ''),
             'source': match_info.get('source', 'unknown'),

--- a/src/tally/commands/run.py
+++ b/src/tally/commands/run.py
@@ -35,6 +35,16 @@ from ..parsers import ParseResult, SkippedRow
 from collections import Counter
 
 
+def collect_source_names(data_sources):
+    """Collect source names for the report subtitle (exclude supplemental).
+
+    Deduplicates while preserving the order sources are declared in settings.yaml.
+    """
+    return list(dict.fromkeys(
+        s.get('name', 'Unknown') for s in data_sources if not s.get('_supplemental', False)
+    ))
+
+
 def cmd_run(args):
     """Handle the 'run' subcommand."""
     config_dir = resolve_config_dir(args)
@@ -316,7 +326,7 @@ def cmd_run(args):
             output_path = os.path.join(output_dir, config.get('html_filename', 'spending_summary.html'))
 
         # Collect source names for the report subtitle (exclude supplemental)
-        source_names = [s.get('name', 'Unknown') for s in data_sources if not s.get('_supplemental', False)]
+        source_names = collect_source_names(data_sources)
         write_summary_file_vue(stats, output_path, title=title,
                                currency_format=currency_format, sources=source_names,
                                embedded_html=args.embedded_html)

--- a/tests/test_analyzer.py
+++ b/tests/test_analyzer.py
@@ -7,6 +7,8 @@ import os
 from datetime import date
 
 from tally.analyzer import parse_amount, analyze_transactions, export_json, export_csv, classify_by_sections
+from tally.analyzer import build_merchant_json
+from tally.commands.run import collect_source_names
 from tally.analyzer import parse_generic_csv as _parse_generic_csv
 from tally.parsers import SkippedRow, ParseResult, _detect_date_format
 from tally.format_parser import parse_format_string
@@ -273,6 +275,48 @@ class TestExportJson:
         assert 'total' in parsed['by_month']['2025-01']
         assert parsed['by_month']['2025-01']['total'] == 55.0
         assert parsed['by_month']['2025-02']['total'] == 25.0
+
+
+class TestReportJsonDeterminism:
+    """The report JSON is diffed against the previous run, so it must be reproducible."""
+
+    def test_pattern_tags_sorted_when_list(self):
+        """match_info['tags'] arrives as a list built from a set - sort it anyway."""
+        result = build_merchant_json('AMAZON', {
+            'match_info': {'pattern': 'AMAZON*', 'source': 'merchants.rules',
+                           'tags': ['zeta', 'alpha', 'mid']},
+        })
+
+        assert result['pattern']['tags'] == ['alpha', 'mid', 'zeta']
+
+    def test_pattern_tags_sorted_when_set(self):
+        """The path the dead isinstance guard used to cover."""
+        result = build_merchant_json('AMAZON', {
+            'match_info': {'pattern': 'AMAZON*', 'source': 'merchants.rules',
+                           'tags': {'zeta', 'alpha', 'mid'}},
+        })
+
+        assert result['pattern']['tags'] == ['alpha', 'mid', 'zeta']
+
+    def test_source_names_dedupe_preserves_declaration_order(self):
+        """Duplicate source names collapse without being reordered."""
+        data_sources = [
+            {'name': 'B', 'file': 'b1.csv'},
+            {'name': 'A', 'file': 'a.csv'},
+            {'name': 'B', 'file': 'b2.csv'},
+        ]
+
+        assert collect_source_names(data_sources) == ['B', 'A']
+
+    def test_source_names_excludes_supplemental(self):
+        """Supplemental sources produce no transactions, so they stay out of the subtitle."""
+        data_sources = [
+            {'name': 'B', 'file': 'b.csv'},
+            {'name': 'Orders', 'file': 'orders.csv', '_supplemental': True},
+            {'name': 'A', 'file': 'a.csv'},
+        ]
+
+        assert collect_source_names(data_sources) == ['B', 'A']
 
 
 class TestExportCsv:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -7,6 +7,166 @@ import os
 from pathlib import Path
 
 
+class TestGlobPatternSupport:
+    """Tests for wildcard/glob pattern support in data source file paths."""
+
+    def test_glob_pattern_matches_multiple_files(self):
+        """Glob pattern should match multiple CSV files."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config_dir = os.path.join(tmpdir, 'config')
+            data_dir = os.path.join(tmpdir, 'data')
+            os.makedirs(config_dir)
+            os.makedirs(data_dir)
+
+            # Create settings with glob pattern
+            with open(os.path.join(config_dir, 'settings.yaml'), 'w') as f:
+                f.write("""year: 2025
+data_sources:
+  - name: TestBank
+    file: data/test*.csv
+    format: "{date:%Y-%m-%d},{description},{amount}"
+""")
+
+            # Create multiple matching files
+            with open(os.path.join(data_dir, 'test-jan.csv'), 'w') as f:
+                f.write("date,description,amount\n")
+                f.write("2025-01-15,NETFLIX,-15.99\n")
+
+            with open(os.path.join(data_dir, 'test-feb.csv'), 'w') as f:
+                f.write("date,description,amount\n")
+                f.write("2025-02-15,SPOTIFY,-9.99\n")
+
+            result = subprocess.run(
+                ['uv', 'run', 'tally', 'run', '--format', 'summary', config_dir],
+                capture_output=True,
+                text=True
+            )
+            assert result.returncode == 0
+            # Should report transactions from 2 files
+            assert '2 files' in result.stdout
+            assert '2 transactions' in result.stdout
+
+    def test_glob_pattern_single_file_fallback(self):
+        """Single file path (no wildcards) should still work."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config_dir = os.path.join(tmpdir, 'config')
+            data_dir = os.path.join(tmpdir, 'data')
+            os.makedirs(config_dir)
+            os.makedirs(data_dir)
+
+            with open(os.path.join(config_dir, 'settings.yaml'), 'w') as f:
+                f.write("""year: 2025
+data_sources:
+  - name: TestBank
+    file: data/transactions.csv
+    format: "{date:%Y-%m-%d},{description},{amount}"
+""")
+
+            with open(os.path.join(data_dir, 'transactions.csv'), 'w') as f:
+                f.write("date,description,amount\n")
+                f.write("2025-01-15,TEST,-10.00\n")
+
+            result = subprocess.run(
+                ['uv', 'run', 'tally', 'run', '--format', 'summary', config_dir],
+                capture_output=True,
+                text=True
+            )
+            assert result.returncode == 0
+            assert 'TestBank: 1 transactions' in result.stdout
+            assert '1 transactions' in result.stdout
+
+    def test_glob_pattern_no_matches_shows_error(self):
+        """Glob pattern with no matches should show helpful message."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config_dir = os.path.join(tmpdir, 'config')
+            data_dir = os.path.join(tmpdir, 'data')
+            os.makedirs(config_dir)
+            os.makedirs(data_dir)
+
+            with open(os.path.join(config_dir, 'settings.yaml'), 'w') as f:
+                f.write("""year: 2025
+data_sources:
+  - name: TestBank
+    file: data/nonexistent*.csv
+    format: "{date:%Y-%m-%d},{description},{amount}"
+""")
+
+            result = subprocess.run(
+                ['uv', 'run', 'tally', 'run', '--format', 'summary', config_dir],
+                capture_output=True,
+                text=True
+            )
+            # Should report that no files matched the glob pattern
+            assert result.returncode == 1
+            assert 'No files matched' in result.stdout
+            assert 'data/nonexistent*.csv' in result.stdout
+
+    def test_glob_diag_shows_matched_files(self):
+        """Diag command should show matched files for glob patterns."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config_dir = os.path.join(tmpdir, 'config')
+            data_dir = os.path.join(tmpdir, 'data')
+            os.makedirs(config_dir)
+            os.makedirs(data_dir)
+
+            with open(os.path.join(config_dir, 'settings.yaml'), 'w') as f:
+                f.write("""year: 2025
+data_sources:
+  - name: TestBank
+    file: data/test*.csv
+    format: "{date:%Y-%m-%d},{description},{amount}"
+""")
+
+            # Create multiple matching files
+            with open(os.path.join(data_dir, 'test-a.csv'), 'w') as f:
+                f.write("date,description,amount\n")
+
+            with open(os.path.join(data_dir, 'test-b.csv'), 'w') as f:
+                f.write("date,description,amount\n")
+
+            result = subprocess.run(
+                ['uv', 'run', 'tally', 'diag', config_dir],
+                capture_output=True,
+                text=True
+            )
+            assert result.returncode == 0
+            # Should show the configured glob and resolved file count
+            assert 'data/test*.csv' in result.stdout
+            assert '(2 files)' in result.stdout
+
+    def test_glob_files_processed_in_sorted_order(self):
+        """Files should be processed in sorted order for consistency."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config_dir = os.path.join(tmpdir, 'config')
+            data_dir = os.path.join(tmpdir, 'data')
+            os.makedirs(config_dir)
+            os.makedirs(data_dir)
+
+            with open(os.path.join(config_dir, 'settings.yaml'), 'w') as f:
+                f.write("""year: 2025
+data_sources:
+  - name: TestBank
+    file: data/*.csv
+    format: "{date:%Y-%m-%d},{description},{amount}"
+""")
+
+            # Create files in non-alphabetical order
+            with open(os.path.join(data_dir, 'z-last.csv'), 'w') as f:
+                f.write("date,description,amount\n")
+                f.write("2025-01-01,Z_FIRST,-1.00\n")
+
+            with open(os.path.join(data_dir, 'a-first.csv'), 'w') as f:
+                f.write("date,description,amount\n")
+                f.write("2025-01-01,A_FIRST,-1.00\n")
+
+            # Resolver should return files in sorted order regardless of creation order
+            from tally.path_utils import resolve_data_source_paths
+
+            files, _ = resolve_data_source_paths(config_dir, 'data/*.csv')
+            basenames = [os.path.basename(f) for f in files]
+            assert basenames == ['a-first.csv', 'z-last.csv']
+
+
 class TestCLIErrorHandling:
     """Tests for helpful error messages when CLI is misused."""
 


### PR DESCRIPTION
> **[2/6]** Based on `feature/globbing-documentation` (#98).
> Merging this PR into `main` also lands #98 if not already merged.
> **This layer only:** [`feature/globbing-documentation...feature/report-json-determinism`](https://github.com/terryaney/OpenSource.tally/compare/feature/globbing-documentation...feature/report-json-determinism)

`tally up` writes `<output>.json` beside the HTML report and diffs the next run against it — that file is the baseline for the "Changes since last run" message. The same config against the same data should produce the same bytes, but currently doesn't — `pattern.tags` serializes in arbitrary order because Python randomizes hash seeds per process.

## Changes

- **`analyzer.py`** — sort `pattern.tags` unconditionally; the existing `isinstance(set)` guard never fired because the value arrives as a list
- **`run.py`** — extract `collect_source_names()` to deduplicate the report subtitle's source list (order-preserving)
- **`tests/test_analyzer.py`** — four tests covering both fixes

Two source files, one test file. No rule-engine change, no change to HTML rendering or any other export format.

**Accepted consequence:** the rule info popup now lists a rule's tags alphabetically rather than in rule-declaration order — consistent with the top-level tags list, which was already alphabetical.

## Stack

| # | Branch | PR | Description | Diff |
|---|---|---|---|---|
| 1 | `feature/globbing-documentation` | #98 | Glob pattern docs and CLI tests | [from main](https://github.com/terryaney/OpenSource.tally/compare/main...feature/globbing-documentation) |
| **2** | **`feature/report-json-determinism`** | **#99** | **Deterministic report JSON** | **[from PR98](https://github.com/terryaney/OpenSource.tally/compare/feature/globbing-documentation...feature/report-json-determinism) · [from main](https://github.com/terryaney/OpenSource.tally/compare/main...feature/report-json-determinism)** |
| 3 | `feature/ui-tweaks` | #100 | Date filter, transaction details, per-txn tags | [from PR99](https://github.com/terryaney/OpenSource.tally/compare/feature/report-json-determinism...feature/ui-tweaks) · [from main](https://github.com/terryaney/OpenSource.tally/compare/main...feature/ui-tweaks) |
| 4 | `feature/charts-reimagined` | #101 | Reimagined charts and KPIs | [from PR100](https://github.com/terryaney/OpenSource.tally/compare/feature/ui-tweaks...feature/charts-reimagined) · [from main](https://github.com/terryaney/OpenSource.tally/compare/main...feature/charts-reimagined) |
| 5 | `feature/merchant-composite-keys` | #102 | Composite merchant keys | [from PR101](https://github.com/terryaney/OpenSource.tally/compare/feature/charts-reimagined...feature/merchant-composite-keys) · [from main](https://github.com/terryaney/OpenSource.tally/compare/main...feature/merchant-composite-keys) |
| 6 | `feature/categorization` | #103 | Categorization review file | [from PR102](https://github.com/terryaney/OpenSource.tally/compare/feature/merchant-composite-keys...feature/categorization) · [from main](https://github.com/terryaney/OpenSource.tally/compare/main...feature/categorization) |

Independent: [`feature/ci-repair`](https://github.com/terryaney/OpenSource.tally/compare/main...feature/ci-repair) — #97 — fixes fork PR builds.