### PR TITLE
Date filtering, transaction details, and per-transaction tag classification [3/6]

### DIFF
--- a/config/settings.yaml.example
+++ b/config/settings.yaml.example
@@ -15,10 +15,15 @@ title: "Spending Analysis"
 
 # Data sources - list of transaction files to process
 # Paths are relative to the parent of the config directory
+# Supports glob patterns (*, ?, []) to match multiple files
 data_sources:
   - name: AMEX
-    file: data/amex-2025.csv
+    file: data/amex-2025.csv      # Single file
     type: amex
+  # Example with glob pattern to match multiple files:
+  # - name: AMEX
+  #   file: data/amex*.csv        # Matches amex-2024.csv, amex-2025.csv, etc.
+  #   type: amex
   - name: BOA
     file: data/boa-checking.txt
     type: boa

--- a/config/settings.yaml.example
+++ b/config/settings.yaml.example
@@ -50,6 +50,21 @@ data_sources:
   #   columns:
   #     description: "{vendor} ({txn_type})"  # Combines columns into description
 
+  # Per-source report_fields override (when columns differ per account):
+  # - name: Wells Fargo Visa
+  #   file: data/visa.csv
+  #   format: "{date:%m/%d/%Y},{description},{memo},{amount}"
+  #   report_fields: [memo]
+
+# Capture columns to surface in the report's transaction details popup.
+# Any name here that a source's format string captures - e.g. {memo} - is shown
+# when non-blank; transactions without a value get no details badge. Names a
+# source does not capture are ignored, so a global list is safe with mixed
+# formats. A source-level report_fields replaces this list for that source.
+
+report_fields:
+  - memo
+
 # Output settings
 output_dir: output
 html_filename: spending_summary.html

--- a/docs/formats.html
+++ b/docs/formats.html
@@ -255,7 +255,7 @@
             <tr>
                 <td><code>file</code></td>
                 <td>Yes</td>
-                <td>Path to CSV file (relative or absolute), supports glob patterns (`*`, `?`, `[]`) to match multiple files (files are processed in sorted order)</td>
+                <td>Path to CSV file (relative or absolute), supports glob patterns (<code>*</code>, <code>?</code>, <code>[]</code>) to match multiple files (files are processed in sorted order)</td>
             </tr>
             <tr>
                 <td><code>format</code></td>

--- a/docs/formats.html
+++ b/docs/formats.html
@@ -361,6 +361,11 @@
 <span class="comment"># match: field.txn_type == "WIRE"</span>
 <span class="comment"># match: contains(field.memo, "Invoice")</span></code></pre>
 
+        <p>A captured column is available to rule expressions, but is not shown in the report until you ask for it. The simplest way is <code>report_fields</code>, which surfaces the column as-is:</p>
+        <pre><code><span class="highlight">report_fields:</span>
+  - memo</code></pre>
+        <p>Transactions with a blank value show no details badge. A rule's <a href="reference.html#field-directive"><code>field:</code> directive</a> also shows up in the popup, and is what you want when the value needs computing rather than copying. See the <a href="reference.html#report-fields">rules reference</a> for per-source overrides and how the two interact.</p>
+
         <h3>Combining Columns into Description</h3>
         <p>Some CSVs split transaction info across multiple columns. Use <code>columns.description</code> to combine them:</p>
         <pre><code><span class="comment"># CSV: Date, Category, Payee, Reference, Amount</span>

--- a/docs/formats.html
+++ b/docs/formats.html
@@ -255,7 +255,7 @@
             <tr>
                 <td><code>file</code></td>
                 <td>Yes</td>
-                <td>Path to CSV file (relative or absolute)</td>
+                <td>Path to CSV file (relative or absolute), supports glob patterns (`*`, `?`, `[]`) to match multiple files (files are processed in sorted order)</td>
             </tr>
             <tr>
                 <td><code>format</code></td>

--- a/docs/reference.html
+++ b/docs/reference.html
@@ -456,6 +456,47 @@ field.description = regex_replace(field.description, <span class="string">"^APLP
         <p>Use <code>exists(field.name)</code> to safely check if a field exists:</p>
         <pre><code><span class="keyword">match:</span> exists(field.memo) and contains(field.memo, <span class="string">"REF"</span>)</code></pre>
 
+        <h3 id="report-fields"><a href="#report-fields" class="anchor-link">#</a>Showing Fields in the Report</h3>
+        <p>Captured fields power rule expressions only. To also show one in the report's transaction details popup, name it in <code>report_fields</code>:</p>
+        <pre><code><span class="comment"># In settings.yaml - applies to every source:</span>
+<span class="keyword">report_fields:</span>
+  - memo
+
+<span class="comment"># Or per source, when columns differ per account:</span>
+<span class="keyword">data_sources:</span>
+  - <span class="keyword">name:</span> Visa
+    <span class="keyword">format:</span> <span class="string">"{date},{description},{memo},{amount}"</span>
+    <span class="keyword">report_fields:</span> [memo]</code></pre>
+
+        <p>Blank values are omitted, so transactions without a memo show no details badge. A global <code>report_fields</code> entry that a source does not capture is ignored, making it safe to use across accounts with different columns. A source-level <code>report_fields</code> replaces the global list for that source.</p>
+
+        <h3 id="report-fields-vs-field"><a href="#report-fields-vs-field" class="anchor-link">#</a>report_fields vs. the field: directive</h3>
+        <p>Both put values in the transaction details popup. They differ in what they can express and where they apply:</p>
+        <table>
+            <tr>
+                <th></th>
+                <th><code>report_fields</code></th>
+                <th><code>field:</code></th>
+            </tr>
+            <tr>
+                <td>Value</td>
+                <td>The captured column, as-is</td>
+                <td>Any expression &mdash; <code>extract()</code>, cross-source lookups, computed counts</td>
+            </tr>
+            <tr>
+                <td>Applies to</td>
+                <td>Every transaction from the source</td>
+                <td>Only transactions matching that rule</td>
+            </tr>
+            <tr>
+                <td>Declared in</td>
+                <td><code>settings.yaml</code> (global or per source)</td>
+                <td><code>merchants.rules</code> (per rule)</td>
+            </tr>
+        </table>
+        <p>Use <code>report_fields</code> to show a column verbatim; use <code>field:</code> when the value must be derived. A passthrough like <code>field: memo = field.memo</code> is redundant once <code>memo</code> is in <code>report_fields</code> &mdash; and narrower, since it only fires on that rule.</p>
+        <p>When both produce the same key, the <code>field:</code> directive wins. Neither is visible to other rules; they feed the report popup, CSV export columns, and report search only.</p>
+
         <h2 id="extraction"><a href="#extraction" class="anchor-link">#</a>Extraction Functions</h2>
         <table>
             <tr>
@@ -622,8 +663,8 @@ field.memo = trim(field.memo)</code></pre>
 <span class="keyword">category:</span> Shopping
 <span class="keyword">tags:</span> verified</code></pre>
 
-        <h3>The field: Directive</h3>
-        <p>Add computed fields to transactions (visible in HTML report):</p>
+        <h3 id="field-directive"><a href="#field-directive" class="anchor-link">#</a>The field: Directive</h3>
+        <p>Add computed fields to transactions (visible in HTML report). Not needed to read a field in <code>match:</code> &mdash; captured columns are already available there as <code>field.&lt;name&gt;</code>.</p>
         <pre><code><span class="highlight">[Amazon - Verified]</span>
 <span class="keyword">let:</span> orders = [r for r in amazon_orders if r.amount == txn.amount]
 <span class="keyword">match:</span> contains(<span class="string">"AMAZON"</span>) and len(orders) > 0

--- a/docs/reference.html
+++ b/docs/reference.html
@@ -495,7 +495,7 @@ field.description = regex_replace(field.description, <span class="string">"^APLP
             </tr>
         </table>
         <p>Use <code>report_fields</code> to show a column verbatim; use <code>field:</code> when the value must be derived. A passthrough like <code>field: memo = field.memo</code> is redundant once <code>memo</code> is in <code>report_fields</code> &mdash; and narrower, since it only fires on that rule.</p>
-        <p>When both produce the same key, the <code>field:</code> directive wins. Neither is visible to other rules; they feed the report popup, CSV export columns, and report search only.</p>
+        <p>When both produce the same key, the <code>field:</code> directive wins. A <code>field:</code> directive's <em>output</em> is not an input to other rules &mdash; it feeds the report popup, CSV export columns, and report search only. The captured column that <code>report_fields</code> surfaces is a different thing that happens to share the name: it is available to every rule as <code>field.&lt;name&gt;</code>, whether or not you list it in <code>report_fields</code>, which controls display and nothing else.</p>
 
         <h2 id="extraction"><a href="#extraction" class="anchor-link">#</a>Extraction Functions</h2>
         <table>

--- a/src/tally/analyzer.py
+++ b/src/tally/analyzer.py
@@ -363,9 +363,9 @@ def build_merchant_json(merchant_name, data, verbose=0):
     # Add pattern match info if available
     match_info = data.get('match_info')
     if match_info:
-        pattern_tags = match_info.get('tags', [])
-        if isinstance(pattern_tags, set):
-            pattern_tags = sorted(pattern_tags)
+        # Sort unconditionally - tags originate from a set, so a list built from
+        # one carries arbitrary order into the JSON and breaks reproducibility
+        pattern_tags = sorted(match_info.get('tags', []))
         result['pattern'] = {
             'matched': match_info.get('pattern', ''),
             'source': match_info.get('source', 'unknown'),

--- a/src/tally/cli_utils.py
+++ b/src/tally/cli_utils.py
@@ -88,8 +88,6 @@ def resolve_config_dir(args, required=True):
 
 def init_config(target_dir):
     """Initialize a new config directory with starter files."""
-    import datetime
-
     config_dir = os.path.join(target_dir, 'config')
     data_dir = os.path.join(target_dir, 'data')
     output_dir = os.path.join(target_dir, 'output')
@@ -99,7 +97,6 @@ def init_config(target_dir):
     os.makedirs(data_dir, exist_ok=True)
     os.makedirs(output_dir, exist_ok=True)
 
-    current_year = datetime.datetime.now().year
     files_created = []
     files_skipped = []
 
@@ -107,7 +104,8 @@ def init_config(target_dir):
     settings_path = os.path.join(config_dir, 'settings.yaml')
     if not os.path.exists(settings_path):
         with open(settings_path, 'w', encoding='utf-8') as f:
-            f.write(STARTER_SETTINGS.format(year=current_year))
+            # .format() (no args) still unescapes the {{...}} format examples
+            f.write(STARTER_SETTINGS.format())
         files_created.append('config/settings.yaml')
     else:
         files_skipped.append('config/settings.yaml')

--- a/src/tally/commands/reference.py
+++ b/src/tally/commands/reference.py
@@ -115,6 +115,30 @@ def cmd_reference(args):
 
   Use {C.GREEN}exists(field.name){C.RESET} to safely check if a field exists:
   {C.DIM}match: exists(field.memo) and contains(field.memo, "REF"){C.RESET}
+
+  Captured fields power rule expressions only. To also show one in the report's
+  transaction details popup, name it in {C.GREEN}report_fields{C.RESET}:
+
+  {C.DIM}# In settings.yaml (applies to every source):{C.RESET}
+  {C.CYAN}report_fields:{C.RESET}
+  {C.CYAN}  - memo{C.RESET}
+
+  {C.DIM}# Or per source, when columns differ per account:{C.RESET}
+  {C.CYAN}data_sources:{C.RESET}
+  {C.CYAN}  - name: Visa{C.RESET}
+  {C.CYAN}    format: "{{date}},{{description}},{{memo}},{{amount}}"{C.RESET}
+  {C.CYAN}    report_fields: [memo]{C.RESET}
+
+  Blank values are omitted, so transactions without a memo show no details badge.
+  A global {C.GREEN}report_fields{C.RESET} entry that a source does not capture is ignored.
+
+  {C.BOLD}report_fields vs. field:{C.RESET} Both fill the details popup.
+    {C.GREEN}report_fields{C.RESET}  shows a captured column as-is, on every transaction
+    {C.GREEN}field:{C.RESET}         computes a value, only on transactions matching that rule
+
+  A passthrough like {C.DIM}field: memo = field.memo{C.RESET} is redundant once memo is in
+  report_fields. Neither is needed to read a field in {C.GREEN}match:{C.RESET} - captured
+  columns are always available there. On a key collision, {C.GREEN}field:{C.RESET} wins.
 """)
 
         section("Extraction Functions")

--- a/src/tally/commands/run.py
+++ b/src/tally/commands/run.py
@@ -35,6 +35,16 @@ from ..parsers import ParseResult, SkippedRow
 from collections import Counter
 
 
+def collect_source_names(data_sources):
+    """Collect source names for the report subtitle (exclude supplemental).
+
+    Deduplicates while preserving the order sources are declared in settings.yaml.
+    """
+    return list(dict.fromkeys(
+        s.get('name', 'Unknown') for s in data_sources if not s.get('_supplemental', False)
+    ))
+
+
 def cmd_run(args):
     """Handle the 'run' subcommand."""
     config_dir = resolve_config_dir(args)
@@ -316,7 +326,7 @@ def cmd_run(args):
             output_path = os.path.join(output_dir, config.get('html_filename', 'spending_summary.html'))
 
         # Collect source names for the report subtitle (exclude supplemental)
-        source_names = [s.get('name', 'Unknown') for s in data_sources if not s.get('_supplemental', False)]
+        source_names = collect_source_names(data_sources)
         write_summary_file_vue(stats, output_path, title=title,
                                currency_format=currency_format, sources=source_names,
                                embedded_html=args.embedded_html)

--- a/src/tally/config_loader.py
+++ b/src/tally/config_loader.py
@@ -24,7 +24,7 @@ def load_settings(config_dir, settings_file='settings.yaml'):
         return yaml.safe_load(f)
 
 
-def resolve_source_format(source, warnings=None):
+def resolve_source_format(source, warnings=None, report_fields=None):
     """
     Resolve the format specification for a data source.
 
@@ -36,10 +36,14 @@ def resolve_source_format(source, warnings=None):
     - columns.description: Template for combining custom captures
       Example: "{merchant} ({type})" when format uses {type}, {merchant}
     - supplemental: true (data source is query-only, doesn't generate transactions)
+    - report_fields: Capture names to surface in the report, e.g. [memo]
 
     Args:
         source: Data source configuration dict
         warnings: Optional list to append deprecation warnings to
+        report_fields: Global report_fields default, overridden by source-level
+            report_fields. Names absent from this source are silently ignored,
+            since a global default may reference fields only some sources have.
 
     Returns the source dict with additional keys:
     - '_parser_type': 'amex', 'boa', or 'generic'
@@ -93,6 +97,21 @@ def resolve_source_format(source, warnings=None):
                 format_spec.negate_amount = source['negate_amount']
             if 'tags_from_fields' in source:
                 format_spec.tags_from_fields = source['tags_from_fields']
+
+            available = set(format_spec.extra_fields or {}) | set(format_spec.custom_captures or {})
+            if 'report_fields' in source:
+                unknown = [f for f in source['report_fields'] if f not in available]
+                if unknown:
+                    raise ValueError(
+                        f"Source '{source_name}': report_fields references field(s) "
+                        f"{', '.join(sorted(unknown))} not captured by the format string.\n"
+                        f"Captured fields: {', '.join(sorted(available)) or '(none)'}\n"
+                        f"Add the field to your format, e.g. "
+                        f"format: \"{{date}},{{description}},{{{unknown[0]}}},{{amount}}\""
+                    )
+                format_spec.report_fields = list(source['report_fields'])
+            elif report_fields:
+                format_spec.report_fields = [f for f in report_fields if f in available]
 
             source['_format_spec'] = format_spec
             source['_parser_type'] = 'generic'
@@ -154,7 +173,8 @@ def load_config(config_dir, settings_file='settings.yaml'):
     # Process data sources to resolve format specs
     if config.get('data_sources'):
         config['data_sources'] = [
-            resolve_source_format(source, warnings=warnings)
+            resolve_source_format(source, warnings=warnings,
+                                  report_fields=config.get('report_fields'))
             for source in config['data_sources']
         ]
     else:

--- a/src/tally/config_loader.py
+++ b/src/tally/config_loader.py
@@ -24,6 +24,28 @@ def load_settings(config_dir, settings_file='settings.yaml'):
         return yaml.safe_load(f)
 
 
+def normalize_report_fields(value, label='report_fields'):
+    """Coerce a report_fields setting into a list of capture names.
+
+    YAML hands back whatever was typed. `report_fields: memo` is a bare string,
+    which iterating treats as the four capture names m, e, m, o; an empty
+    `report_fields:` is None, which is not iterable at all. Accept the bare
+    string as the single name it plainly means, treat an empty value as "none",
+    and reject anything else by name rather than letting it become a TypeError
+    from somewhere further down.
+    """
+    if value is None:
+        return []
+    if isinstance(value, str):
+        return [value]
+    if not isinstance(value, list) or not all(isinstance(f, str) for f in value):
+        raise ValueError(
+            f"{label} must be a capture name or a list of capture names, "
+            f"got {type(value).__name__}: {value!r}"
+        )
+    return list(value)
+
+
 def resolve_source_format(source, warnings=None, report_fields=None):
     """
     Resolve the format specification for a data source.
@@ -100,7 +122,8 @@ def resolve_source_format(source, warnings=None, report_fields=None):
 
             available = set(format_spec.extra_fields or {}) | set(format_spec.custom_captures or {})
             if 'report_fields' in source:
-                unknown = [f for f in source['report_fields'] if f not in available]
+                requested = normalize_report_fields(source['report_fields'])
+                unknown = [f for f in requested if f not in available]
                 if unknown:
                     raise ValueError(
                         f"Source '{source_name}': report_fields references field(s) "
@@ -109,9 +132,12 @@ def resolve_source_format(source, warnings=None, report_fields=None):
                         f"Add the field to your format, e.g. "
                         f"format: \"{{date}},{{description}},{{{unknown[0]}}},{{amount}}\""
                     )
-                format_spec.report_fields = list(source['report_fields'])
+                format_spec.report_fields = requested
             elif report_fields:
-                format_spec.report_fields = [f for f in report_fields if f in available]
+                global_fields = normalize_report_fields(
+                    report_fields, label='report_fields (settings.yaml top level)'
+                )
+                format_spec.report_fields = [f for f in global_fields if f in available]
 
             source['_format_spec'] = format_spec
             source['_parser_type'] = 'generic'

--- a/src/tally/format_parser.py
+++ b/src/tally/format_parser.py
@@ -25,6 +25,7 @@ class FormatSpec:
     negate_amount: bool = False  # If True, flip the sign of amounts (use {-amount} in format)
     abs_amount: bool = False  # If True, take absolute value of amounts (use {+amount} in format)
     delimiter: Optional[str] = None  # Column delimiter: None=comma, 'tab', 'whitespace', or regex pattern
+    report_fields: Optional[list] = None  # Capture names surfaced in the report (see report_fields setting)
 
 
 # Reserved field names that cannot be used for custom captures

--- a/src/tally/merchant_engine.py
+++ b/src/tally/merchant_engine.py
@@ -421,7 +421,10 @@ class MerchantEngine:
     ) -> Dict[str, Any]:
         """Evaluate field expressions for a matching rule.
 
-        Returns dict of field_name -> evaluated_value.
+        Returns dict of field_name -> evaluated_value. Fields evaluating to an
+        empty value are omitted, so a transaction lacking the underlying data
+        carries no field at all rather than a blank one. Zero and False are
+        retained - only None and empty strings/lists/dicts are dropped.
         """
         evaluated = {}
         for field_name, expr in rule.fields.items():
@@ -429,6 +432,8 @@ class MerchantEngine:
                 result = expr_parser.evaluate_transaction(
                     expr, transaction, variables=variables, data_sources=data_sources
                 )
+                if result is None or (isinstance(result, (str, list, dict)) and not result):
+                    continue
                 evaluated[field_name] = result
             except expr_parser.ExpressionError:
                 # If field evaluation fails, skip it

--- a/src/tally/merchant_utils.py
+++ b/src/tally/merchant_utils.py
@@ -561,6 +561,7 @@ def normalize_merchant(
         if result.matched:
             match_info = {
                 'pattern': result.matched_rule.match_expr if result.matched_rule else None,
+                'rule_name': result.matched_rule.name if result.matched_rule else None,
                 'source': 'user',
                 'tags': list(result.tags),
             }
@@ -579,7 +580,13 @@ def normalize_merchant(
         # No categorization match - fallback to extract merchant name
         merchant_name = extract_merchant_name(description)
         if result.tags or raw_values:
-            match_info = {'pattern': None, 'source': 'auto', 'tags': list(result.tags)}
+            first_tag_rule = result.tag_rules[0] if result.tag_rules else None
+            match_info = {
+                'pattern': first_tag_rule.match_expr if first_tag_rule else None,
+                'rule_name': first_tag_rule.name if first_tag_rule else None,
+                'source': 'user' if first_tag_rule else 'auto',
+                'tags': list(result.tags),
+            }
             if result.tag_sources:
                 match_info['tag_sources'] = result.tag_sources
             if raw_values:
@@ -602,6 +609,9 @@ def normalize_merchant(
     all_tags = []
     # Track which rule added each tag: {tag: (rule_name, pattern)}
     tag_sources = {}
+    first_tag_rule = None
+    first_tag_pattern = None
+    first_tag_source = 'auto'
 
     for rule in rules:
         # Handle various formats: 4-tuple, 5-tuple, 6-tuple, 7-tuple (with tags)
@@ -641,10 +651,14 @@ def normalize_merchant(
             if tags:
                 resolved_tags = _resolve_dynamic_tags(tags, transaction)
                 all_tags.extend(resolved_tags)
+                if resolved_tags and first_tag_rule is None:
+                    first_tag_rule = merchant
+                    first_tag_pattern = pattern
+                    first_tag_source = source
                 # Track which rule added each tag (first rule wins for each tag)
                 for tag in resolved_tags:
                     if tag not in tag_sources:
-                        tag_sources[tag] = {'rule': source, 'pattern': pattern}
+                        tag_sources[tag] = {'rule': merchant, 'pattern': pattern}
 
             # Use first categorization rule for merchant/category/subcategory
             # Tag-only rules have empty category
@@ -662,7 +676,12 @@ def normalize_merchant(
     # Return matched result with all collected tags (deduplicated, order preserved)
     unique_tags = list(dict.fromkeys(all_tags))
     if result_merchant is not None:
-        match_info = {'pattern': result_pattern, 'source': result_source, 'tags': unique_tags}
+        match_info = {
+            'pattern': result_pattern,
+            'rule_name': result_merchant,
+            'source': result_source,
+            'tags': unique_tags,
+        }
         if tag_sources:
             match_info['tag_sources'] = tag_sources
         if raw_values:
@@ -673,7 +692,12 @@ def normalize_merchant(
     # Still include any tags from tag-only rules that matched
     merchant_name = extract_merchant_name(description)
     if unique_tags or raw_values:
-        match_info = {'pattern': None, 'source': 'auto', 'tags': unique_tags}
+        match_info = {
+            'pattern': first_tag_pattern,
+            'rule_name': first_tag_rule,
+            'source': first_tag_source,
+            'tags': unique_tags,
+        }
         if tag_sources:
             match_info['tag_sources'] = tag_sources
         if raw_values:

--- a/src/tally/parsers.py
+++ b/src/tally/parsers.py
@@ -415,9 +415,20 @@ def parse_generic_csv(filepath, format_spec, rules, source_name='CSV',
             if match_info and match_info.get('raw_values'):
                 for key, value in match_info['raw_values'].items():
                     txn[key] = value
-            # Add extra_fields from field: directives in .rules files
+            # Surface CSV captures named in report_fields, skipping blanks so a
+            # transaction without the field shows no detail badge at all
+            extra_fields = {}
+            if format_spec.report_fields:
+                extra_fields = {
+                    name: captures[name]
+                    for name in format_spec.report_fields
+                    if captures.get(name)
+                }
+            # Add extra_fields from field: directives in .rules files (these win)
             if match_info and match_info.get('extra_fields'):
-                txn['extra_fields'] = match_info['extra_fields']
+                extra_fields.update(match_info['extra_fields'])
+            if extra_fields:
+                txn['extra_fields'] = extra_fields
             # Apply transform_description if set
             if match_info and match_info.get('transform_description'):
                 txn['original_description'] = txn.get('raw_description', txn.get('description', ''))

--- a/src/tally/report.py
+++ b/src/tally/report.py
@@ -4,6 +4,7 @@ HTML Report Generation - Generate spending analysis HTML reports.
 This module handles generation of interactive HTML reports from analyzed transaction data.
 """
 
+import html
 import json
 import sys
 from collections import defaultdict
@@ -332,9 +333,21 @@ def write_summary_file_vue(stats, filepath, year=None, currency_format="${amount
         'investmentTotal': stats.get('investment_total', 0),
     }
 
-    # Assemble final HTML
-    resolved_title = title or 'Tally Spending Analysis'
-    data_script = f'window.spendingData = {json.dumps(spending_data)};'
+    # Assemble final HTML.
+    # Resolve the title once, here, and store it back so the static loading
+    # shell and the mounted Vue app cannot disagree about what the report is
+    # called. YAML hands us whatever the user typed - `title: 2025` arrives as
+    # an int - so coerce before it reaches str.replace().
+    resolved_title = str(title) if title not in (None, '') else 'Tally Spending Analysis'
+    spending_data['title'] = resolved_title
+    # The shell interpolates the title into markup, so it must be escaped;
+    # the Vue path gets the raw value and escapes it at render time.
+    shell_title = html.escape(resolved_title, quote=True)
+    # A '</' in any string value would close the <script> element this gets
+    # embedded in. '\/' is a valid JSON escape for '/', so the payload still
+    # parses to the identical value while being inert to the HTML tokenizer.
+    data_json = json.dumps(spending_data).replace('</', '<\\/')
+    data_script = f'window.spendingData = {data_json};'
 
     if not embedded_html:
         # Write separate files for easier development
@@ -355,7 +368,7 @@ def write_summary_file_vue(stats, filepath, year=None, currency_format="${amount
 
         # Create HTML with external references
         final_html = html_template.replace(
-            '__REPORT_TITLE__', resolved_title
+            '__REPORT_TITLE__', shell_title
         ).replace(
             '<style>/* CSS_PLACEHOLDER */</style>',
             '<link rel="stylesheet" href="spending_report.css">'
@@ -369,7 +382,7 @@ def write_summary_file_vue(stats, filepath, year=None, currency_format="${amount
     else:
         # Embed everything inline (default)
         final_html = html_template.replace(
-            '__REPORT_TITLE__', resolved_title
+            '__REPORT_TITLE__', shell_title
         ).replace(
             '/* CSS_PLACEHOLDER */', css_content
         ).replace(

--- a/src/tally/report.py
+++ b/src/tally/report.py
@@ -154,6 +154,7 @@ def write_summary_file_vue(stats, filepath, year=None, currency_format="${amount
                 pattern = match_info.get('pattern', '')
                 match_info_json = {
                     'pattern': pattern,
+                    'ruleName': match_info.get('rule_name', ''),
                     'source': match_info.get('source', ''),
                     'explanation': explain_pattern(pattern),
                     'assignedMerchant': merchant_name,
@@ -332,6 +333,7 @@ def write_summary_file_vue(stats, filepath, year=None, currency_format="${amount
     }
 
     # Assemble final HTML
+    resolved_title = title or 'Tally Spending Analysis'
     data_script = f'window.spendingData = {json.dumps(spending_data)};'
 
     if not embedded_html:
@@ -353,6 +355,8 @@ def write_summary_file_vue(stats, filepath, year=None, currency_format="${amount
 
         # Create HTML with external references
         final_html = html_template.replace(
+            '__REPORT_TITLE__', resolved_title
+        ).replace(
             '<style>/* CSS_PLACEHOLDER */</style>',
             '<link rel="stylesheet" href="spending_report.css">'
         ).replace(
@@ -365,6 +369,8 @@ def write_summary_file_vue(stats, filepath, year=None, currency_format="${amount
     else:
         # Embed everything inline (default)
         final_html = html_template.replace(
+            '__REPORT_TITLE__', resolved_title
+        ).replace(
             '/* CSS_PLACEHOLDER */', css_content
         ).replace(
             '/* DATA_PLACEHOLDER */', data_script

--- a/src/tally/spending_report.css
+++ b/src/tally/spending_report.css
@@ -13,6 +13,7 @@
     --bg-input-focus: rgba(255,255,255,0.08);
     --bg-table: rgba(255,255,255,0.03);
     --bg-table-header: rgba(255,255,255,0.05);
+    --bg-sticky: #22243a; /* opaque fill for pinned table header/footer */
     --bg-table-hover: rgba(255,255,255,0.03);
     --bg-tooltip: rgba(0,0,0,0.9);
     --bg-txn-row: rgba(0,0,0,0.2);
@@ -22,6 +23,7 @@
     --bg-highlight: rgba(255, 230, 0, 0.3);
     --bg-code: rgba(255,255,255,0.08);
     --bg-help: rgba(255,255,255,0.02);
+    --bg-popup: #1a1a1a;
 
     /* Text */
     --text-primary: #e8e8e8;
@@ -54,6 +56,7 @@
     --accent-pink-dark: #fa709a;
     --accent-red: #ff6b6b;
     --accent-green: #4ade80;
+    --accent-purple: #9b59b6;
     --accent-negative: #663636;
 
     /* Special */
@@ -75,6 +78,7 @@
     --bg-input-focus: rgba(0,0,0,0.05);
     --bg-table: rgba(0,0,0,0.02);
     --bg-table-header: rgba(0,0,0,0.04);
+    --bg-sticky: #e8ecf2; /* opaque fill for pinned table header/footer */
     --bg-table-hover: rgba(0,0,0,0.03);
     --bg-tooltip: rgba(30,30,30,0.95);
     --bg-txn-row: rgba(0,0,0,0.04);
@@ -84,6 +88,7 @@
     --bg-highlight: rgba(255, 200, 0, 0.3);
     --bg-code: rgba(0,0,0,0.06);
     --bg-help: rgba(0,0,0,0.02);
+    --bg-popup: #ffffff;
 
     --text-primary: #1a1a2e;
     --text-secondary: #555;
@@ -126,6 +131,75 @@ body {
     min-height: 100vh;
     padding: 2rem;
 }
+
+[v-cloak] { display: none; }
+
+body.app-initializing #app {
+    opacity: 0;
+    pointer-events: none;
+}
+
+body.app-ready #app {
+    opacity: 1;
+    transition: opacity 0.22s ease;
+}
+
+.app-loading-shell {
+    display: none;
+}
+
+body.app-initializing .app-loading-shell {
+    display: block;
+}
+
+body.app-ready .app-loading-shell {
+    display: none;
+}
+
+.loading-header {
+    text-align: center;
+    margin-bottom: 1.25rem;
+    padding-bottom: 1rem;
+    border-bottom: 1px solid var(--border-light);
+}
+
+.loading-title {
+    font-size: 2.5rem;
+    font-weight: 300;
+    margin-bottom: 0.45rem;
+    background: linear-gradient(90deg, var(--accent-blue), var(--accent-blue-light));
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
+    background-clip: text;
+}
+
+.loading-subtitle {
+    color: var(--text-secondary);
+    font-size: 0.9rem;
+}
+
+.loading-progress-wrap {
+    height: 12px;
+    border-radius: 999px;
+    border: 1px solid var(--border-medium);
+    background: var(--bg-input);
+    overflow: hidden;
+    box-shadow: inset 0 1px 2px rgba(0,0,0,0.08);
+}
+
+.loading-progress-bar {
+    height: 100%;
+    width: 8%;
+    border-radius: inherit;
+    background: linear-gradient(90deg, var(--accent-blue), var(--accent-cyan));
+    animation: report-loading-progress 0.8s ease-out forwards;
+}
+
+@keyframes report-loading-progress {
+    0% { width: 8%; }
+    55% { width: 72%; }
+    100% { width: 96%; }
+}
 .container {
     max-width: 1200px;
     margin: 0 auto;
@@ -150,10 +224,15 @@ h1 {
     color: var(--text-secondary);
     font-size: 0.9rem;
 }
-.theme-toggle {
+.header-actions {
     position: absolute;
     top: 0;
     right: 0;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+}
+.theme-toggle {
     background: var(--bg-card);
     border: 1px solid var(--border-medium);
     border-radius: 50%;
@@ -170,9 +249,36 @@ h1 {
     background: var(--bg-card-hover);
     transform: scale(1.1);
 }
+.reset-settings-btn {
+    background: var(--bg-card);
+    border: 1px solid var(--border-medium);
+    border-radius: 50%;
+    width: 36px;
+    height: 36px;
+    cursor: pointer;
+    font-size: 1rem;
+    font-weight: 600;
+    line-height: 1;
+    color: var(--text-secondary);
+    transition: all 0.2s;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+.reset-settings-btn:hover {
+    background: var(--bg-card-hover);
+    color: var(--accent-orange);
+    transform: scale(1.1);
+}
 .search-box {
     margin: 1.5rem 0;
-    text-align: center;
+    /* Flex toolbar (like the datefilter prototype): the search input flexes to
+       fill the row and the date-filter button sits beside it at equal height;
+       filter chips wrap to their own full-width row below. */
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.75rem;
     position: sticky;
     top: 0;
     z-index: 100;
@@ -189,7 +295,6 @@ h1 {
 }
 .search-box input {
     width: 100%;
-    max-width: 500px;
     padding: 0.75rem 1rem;
     border-radius: 8px;
     border: 1px solid var(--border-medium);
@@ -246,19 +351,294 @@ h1 {
     font-weight: 600;
     font-style: normal;
 }
+
+/* ============================================================
+   Date filter popover (Month / Quarter / Year / Custom range)
+   ============================================================ */
+.date-filter-wrap {
+    position: relative;
+    display: flex;
+    /* Stretch to the toolbar row height so the button matches the input. */
+    align-self: stretch;
+    text-align: left;
+}
+.date-filter-trigger {
+    margin-left: 0;
+    height: 100%;
+    background-image: none;
+    padding: 0.6rem 1rem;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    white-space: nowrap;
+}
+.date-filter-trigger .chev {
+    font-size: 0.65rem;
+    color: var(--text-muted);
+    transition: transform 0.15s;
+}
+.date-filter-trigger.open .chev { transform: rotate(180deg); }
+
+.date-popover {
+    position: absolute;
+    top: calc(100% + 10px);
+    /* Anchor to the button's right edge (it sits at the far right of the
+       toolbar) so the popover opens leftward and stays on screen. */
+    right: 0;
+    left: auto;
+    min-width: 360px;
+    max-width: calc(100vw - 2rem);
+    background: var(--bg-gradient-start);
+    border: 1px solid var(--border-medium);
+    border-radius: 12px;
+    box-shadow: 0 16px 48px var(--shadow-scrolled);
+    z-index: 1100;
+    padding: 1rem;
+}
+.date-popover .popover-divider { height: 1px; background: var(--border-light); margin: 0.9rem 0; }
+.date-popover .popover-footer {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-top: 0.9rem;
+    padding-top: 0.75rem;
+    border-top: 1px solid var(--border-light);
+}
+
+/* This / Last rows — two single-row 3-col grids with no divider between them */
+.date-popover .quick-grid {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 0.4rem;
+}
+.date-popover .quick-grid-3col { margin-bottom: 0.4rem; }
+.date-popover .quick-pill {
+    width: 100%;
+    text-align: center;
+    padding: 0.55rem 0.9rem;
+    border-radius: 999px;
+    border: 1px solid var(--border-medium);
+    background: transparent;
+    color: var(--text-secondary);
+    font-size: 0.8rem;
+    cursor: pointer;
+    transition: all 0.15s;
+}
+.date-popover .quick-pill:hover { border-color: var(--accent-blue); color: var(--accent-blue); }
+.date-popover .quick-pill.active {
+    background: var(--accent-blue);
+    border-color: var(--accent-blue);
+    color: #fff;
+    font-weight: 600;
+}
+
+/* Year tabs + Clear */
+.date-popover .year-tabs { display: flex; gap: 0.3rem; margin-bottom: 0.7rem; align-items: center; }
+.date-popover .year-tab {
+    position: relative;
+    padding: 0.3rem 0.8rem;
+    border-radius: 6px;
+    font-size: 0.8rem;
+    cursor: pointer;
+    color: var(--text-secondary);
+    border: 1px solid transparent;
+}
+.date-popover .year-tab.active {
+    background: var(--bg-card-hover);
+    color: var(--accent-blue);
+    border-color: var(--border-medium);
+    font-weight: 600;
+}
+.date-popover .year-tab .dot {
+    position: absolute;
+    top: 3px;
+    right: 3px;
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    background: var(--accent-blue);
+}
+.date-popover .year-tabs .link-btn { margin-left: auto; }
+.date-popover .link-btn {
+    background: none;
+    border: none;
+    color: var(--text-secondary);
+    font-size: 0.8rem;
+    cursor: pointer;
+    padding: 0;
+}
+.date-popover .link-btn:hover { color: var(--accent-red); }
+.date-popover .link-danger { color: var(--accent-red); opacity: 0.85; }
+.date-popover .link-danger:hover { color: var(--accent-red); opacity: 1; }
+.date-popover .apply-btn {
+    background: var(--accent-blue);
+    border: none;
+    color: #fff;
+    padding: 0.5rem 1.1rem;
+    border-radius: 8px;
+    font-size: 0.85rem;
+    font-weight: 600;
+    cursor: pointer;
+    transition: filter 0.15s;
+}
+.date-popover .apply-btn:hover { filter: brightness(1.12); }
+
+/* Month grid */
+.date-popover .month-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 0.4rem; }
+.date-popover .month-cell {
+    padding: 0.55rem 0;
+    text-align: center;
+    border-radius: 8px;
+    border: 1px solid var(--border-light);
+    background: var(--bg-table);
+    color: var(--text-primary);
+    font-size: 0.82rem;
+    cursor: pointer;
+    transition: all 0.15s;
+}
+.date-popover .month-cell:hover { border-color: var(--accent-blue); }
+.date-popover .month-cell.selected {
+    background: rgba(79, 172, 254, 0.22);
+    border-color: var(--accent-blue);
+    color: var(--accent-blue);
+    font-weight: 700;
+}
+
+/* Custom Start / End range */
+.date-popover .daterange-row { display: flex; gap: 0.8rem; }
+.date-popover .date-input-wrap { flex: 1; }
+.date-popover .date-input-wrap > label {
+    display: block;
+    font-size: 0.7rem;
+    color: var(--text-muted);
+    margin-bottom: 0.3rem;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+}
+
+/* Drill-down calendar widget */
+.drill-calendar { position: relative; }
+.drill-calendar .date-input {
+    display: flex;
+    align-items: center;
+    border: 1px solid var(--border-medium);
+    border-radius: 8px;
+    background: var(--bg-input);
+    overflow: hidden;
+    transition: border-color 0.15s;
+}
+.drill-calendar .date-input:focus-within { border-color: var(--accent-blue); }
+.drill-calendar .date-input input[type="text"] {
+    flex: 1;
+    min-width: 0;
+    max-width: none;
+    border: none;
+    background: transparent;
+    padding: 0.55rem 0.7rem;
+    color: var(--text-primary);
+    font-size: 0.85rem;
+    outline: none;
+}
+.drill-calendar .date-input input[type="text"].invalid { color: var(--accent-red); }
+.drill-calendar .cal-btn {
+    border: none;
+    border-left: 1px solid var(--border-light);
+    background: transparent;
+    padding: 0.5rem 0.6rem;
+    cursor: pointer;
+    color: var(--text-muted);
+    font-size: 0.9rem;
+    flex-shrink: 0;
+}
+.drill-calendar .cal-btn:hover { color: var(--accent-blue); }
+.drill-calendar .cal-popover {
+    position: absolute;
+    top: calc(100% + 8px);
+    left: 0;
+    z-index: 60;
+    width: 232px;
+    background: var(--bg-gradient-start);
+    border: 1px solid var(--border-medium);
+    border-radius: 10px;
+    box-shadow: 0 12px 36px var(--shadow-scrolled);
+    padding: 0.75rem;
+}
+.drill-calendar.align-right .cal-popover { left: auto; right: 0; }
+.drill-calendar .cal-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: 0.55rem;
+}
+.drill-calendar .cal-nav {
+    background: none;
+    border: none;
+    color: var(--text-muted);
+    font-size: 1rem;
+    cursor: pointer;
+    padding: 0.15rem 0.5rem;
+    border-radius: 6px;
+    line-height: 1;
+}
+.drill-calendar .cal-nav:hover { color: var(--accent-blue); background: var(--bg-card-hover); }
+.drill-calendar .cal-title { display: flex; gap: 0.35rem; font-size: 0.83rem; font-weight: 600; }
+.drill-calendar .cal-drill {
+    background: none;
+    border: none;
+    color: var(--text-primary);
+    font-size: 0.83rem;
+    font-weight: 600;
+    cursor: pointer;
+    padding: 0.1rem 0.3rem;
+    border-radius: 4px;
+}
+.drill-calendar .cal-drill:hover { color: var(--accent-blue); background: var(--bg-card-hover); }
+.drill-calendar .cal-dow { display: grid; grid-template-columns: repeat(7, 1fr); margin-bottom: 0.2rem; }
+.drill-calendar .cal-dow span { text-align: center; font-size: 0.62rem; color: var(--text-dim); }
+.drill-calendar .cal-days { display: grid; grid-template-columns: repeat(7, 1fr); gap: 2px; }
+.drill-calendar .cal-day {
+    aspect-ratio: 1;
+    border: none;
+    background: transparent;
+    color: var(--text-primary);
+    font-size: 0.76rem;
+    cursor: pointer;
+    border-radius: 6px;
+}
+.drill-calendar .cal-day:hover:not(.empty) { background: var(--bg-card-hover); }
+.drill-calendar .cal-day.empty { cursor: default; pointer-events: none; }
+.drill-calendar .cal-day.today { border: 1px solid var(--accent-blue); }
+.drill-calendar .cal-day.selected { background: var(--accent-blue); color: #fff; font-weight: 700; }
+.drill-calendar .cal-months,
+.drill-calendar .cal-years { display: grid; grid-template-columns: repeat(3, 1fr); gap: 0.4rem; }
+.drill-calendar .cal-cell {
+    padding: 0.5rem 0;
+    text-align: center;
+    border-radius: 8px;
+    border: 1px solid var(--border-light);
+    background: var(--bg-table);
+    color: var(--text-primary);
+    font-size: 0.78rem;
+    cursor: pointer;
+    transition: all 0.15s;
+}
+.drill-calendar .cal-cell:hover { border-color: var(--accent-blue); }
+.drill-calendar .cal-cell.selected {
+    background: rgba(79, 172, 254, 0.22);
+    border-color: var(--accent-blue);
+    color: var(--accent-blue);
+    font-weight: 700;
+}
 .autocomplete-container {
     position: relative;
-    display: inline-block;
-    width: 100%;
-    max-width: 500px;
+    flex: 1;
+    min-width: 200px;
 }
 .autocomplete-list {
     position: absolute;
     top: 100%;
-    left: 50%;
-    transform: translateX(-50%);
+    left: 0;
     width: 100%;
-    max-width: 500px;
     background: var(--bg-gradient-start);
     border: 1px solid var(--border-medium);
     border-top: none;
@@ -313,6 +693,8 @@ h1 {
     gap: 0.5rem;
     margin-top: 0.75rem;
     justify-content: center;
+    /* Wrap onto its own full-width row beneath the search/date-filter toolbar. */
+    flex-basis: 100%;
 }
 .filter-chips:empty {
     display: none;
@@ -359,11 +741,11 @@ h1 {
 .filter-chip.subcategory.include { background: rgba(240, 147, 251, 0.2); color: var(--accent-pink); }
 .filter-chip.merchant { border-color: var(--accent-cyan); }
 .filter-chip.merchant.include { background: rgba(77, 255, 210, 0.2); color: var(--accent-cyan); }
-.filter-chip.month { border-color: var(--accent-purple); }
-.filter-chip.month.include { background: rgba(139, 92, 246, 0.2); color: var(--accent-purple); }
+.filter-chip.month, .filter-chip.daterange { border-color: var(--accent-purple); }
+.filter-chip.month.include, .filter-chip.daterange.include { background: rgba(139, 92, 246, 0.2); color: var(--accent-purple); }
 .filter-chip.tag { border-color: var(--accent-yellow); }
 .filter-chip.tag.include { background: rgba(245, 175, 25, 0.2); color: var(--accent-yellow); }
-.filter-chip.category.exclude, .filter-chip.subcategory.exclude, .filter-chip.merchant.exclude, .filter-chip.month.exclude, .filter-chip.tag.exclude {
+.filter-chip.category.exclude, .filter-chip.subcategory.exclude, .filter-chip.merchant.exclude, .filter-chip.month.exclude, .filter-chip.daterange.exclude, .filter-chip.tag.exclude {
     background: rgba(255, 107, 107, 0.15);
     border-color: var(--accent-red);
     color: var(--accent-red);
@@ -467,6 +849,8 @@ section {
     border-radius: 50%;
     display: inline-block;
     flex-shrink: 0;
+    box-shadow: 0 0 0 3px color-mix(in srgb, var(--dot-color, var(--accent-blue)) 28%, transparent),
+                0 0 8px 1px var(--dot-color, var(--accent-blue));
 }
 .info-icon {
     font-size: 0.85rem;
@@ -510,9 +894,6 @@ section {
     transition: transform 0.3s;
     color: var(--text-muted);
 }
-.section-header.collapsed .toggle {
-    transform: rotate(-90deg);
-}
 .section-header .section-total {
     font-family: 'SF Mono', Monaco, monospace;
     font-size: 1.1rem;
@@ -534,7 +915,24 @@ section.annual-section .section-header h2 { color: var(--accent-yellow); }
 section.travel-section .section-header h2 { color: var(--accent-pink); }
 section.oneoff-section .section-header h2 { color: var(--accent-pink-dark); }
 section.variable-section .section-header h2 { color: var(--accent-cyan); }
-section.category-section .section-header h2 { color: var(--accent-blue); }
+section.category-section .section-header h2 { color: var(--text-primary); }
+
+/* Category = one bordered container; the header's border grows around the table when expanded */
+section.category-section {
+    border: 1px solid var(--border-medium);
+    border-radius: 12px;
+    overflow: hidden;
+    background: var(--bg-table);
+}
+section.category-section > .section-header {
+    background: transparent;
+    border-radius: 0;
+    margin-bottom: 0;
+    border-bottom: 1px solid var(--border-medium);
+}
+section.category-section.is-collapsed > .section-header {
+    border-bottom: none;
+}
 
 /* Subcategory Styles */
 .subcategory-group {
@@ -615,7 +1013,17 @@ section.category-section .section-header h2 { color: var(--accent-blue); }
 .table-wrapper {
     max-height: 500px;
     overflow-y: auto;
-    border-radius: 12px;
+}
+.table-wrapper table {
+    overflow: visible;
+    border-radius: 0;
+}
+.table-wrapper thead th {
+    position: sticky;
+    top: 0;
+    z-index: 3;
+    background: var(--bg-sticky);
+    box-shadow: inset 0 -1px 0 var(--border-medium);
 }
 .table-wrapper::-webkit-scrollbar {
     width: 8px;
@@ -657,6 +1065,9 @@ th:hover {
 th.sorted-asc::after { content: ' ↑'; color: var(--accent-blue); }
 th.sorted-desc::after { content: ' ↓'; color: var(--accent-blue); }
 th:last-child, td:last-child { text-align: right; }
+td.count-col, th.count-col { text-align: center; }
+td.money, th.money { text-align: right; }
+td.pct, th.pct { text-align: right; }
 td {
     padding: 0.85rem 1rem;
     border-top: 1px solid var(--border-table);
@@ -673,9 +1084,15 @@ tr.hidden {
 .pct { font-family: 'SF Mono', Monaco, monospace; color: var(--text-secondary); font-size: 0.85rem; }
 .filter-pct { font-size: 0.5em; color: var(--text-secondary); font-weight: normal; }
 .total-row td {
+    position: sticky;
+    bottom: 0;
+    z-index: 3;
     font-weight: 600;
-    background: var(--bg-table-header);
-    border-top: 2px solid var(--border-light);
+    background: var(--bg-sticky);
+    box-shadow: inset 0 2px 0 var(--border-light);
+}
+.total-row:hover td {
+    background: var(--bg-sticky);
 }
 /* Tag badges in table (colors set dynamically via inline style) */
 .tag-badge {
@@ -742,23 +1159,85 @@ th[data-tooltip] { cursor: pointer; }
 }
 .merchant-row .chevron {
     display: inline-block;
-    width: 1em;
     transition: transform 0.2s;
     color: var(--text-muted);
+    line-height: 1.25;
+    margin-top: 0.1rem;
 }
-.merchant-row.expanded .chevron {
-    transform: rotate(90deg);
+.merchant-row td.merchant {
+    padding-left: 1rem;
+}
+.merchant-cell {
+    display: grid;
+    grid-template-columns: 1.1em minmax(0, 1fr);
+    column-gap: 0.55rem;
+    align-items: start;
+}
+.merchant-body {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: baseline;
+    --merchant-action-gap: 0.45rem;
+    column-gap: var(--merchant-action-gap);
+    row-gap: var(--merchant-action-gap);
+    min-width: 0;
+}
+.merchant-name {
+    display: inline;
+    line-height: 1.25;
+    word-break: break-word;
 }
 .match-info-trigger {
     display: inline-block;
     position: relative;
-    margin-left: 0.5em;
-    font-size: 0.75em;
-    color: #555;
+    margin-left: 0;
+    font-size: inherit;
+    color: var(--text-light);
     cursor: pointer;
 }
 .match-info-trigger:hover {
     color: var(--accent-blue);
+}
+.merchant-actions {
+    display: inline-flex;
+    flex-wrap: nowrap;
+    align-items: center;
+    gap: 0.35em;
+    margin-left: 0;
+    font-size: 0.8em;
+    line-height: 1.1;
+    white-space: nowrap;
+}
+.merchant-actions .match-info-trigger {
+    margin-left: 0;
+}
+.merchant-action-sep {
+    color: var(--text-muted);
+    opacity: 0.8;
+}
+.merchant-filter-trigger {
+    appearance: none;
+    background: none;
+    border: none;
+    color: var(--text-light);
+    font: inherit;
+    font-size: 1em;
+    line-height: 1.1;
+    padding: 0;
+    cursor: pointer;
+}
+.merchant-actions .match-info-trigger,
+.merchant-filter-trigger {
+    font-family: inherit;
+    font-weight: inherit;
+    letter-spacing: normal;
+}
+.merchant-filter-trigger:hover {
+    color: var(--accent-blue);
+}
+td.merchant.clickable:hover {
+    color: inherit;
+    text-decoration: none;
 }
 
 /* Merchant list trigger (in subcategory mode) */
@@ -783,13 +1262,13 @@ th[data-tooltip] { cursor: pointer; }
     position: fixed;
     padding: 1.5em 2em;
     padding-top: 1em;
-    background: #1a1a1a;
-    border: 1px solid #444;
+    background: var(--bg-popup);
+    border: 1px solid var(--border-medium);
     border-radius: 12px;
     font-size: 0.95rem;
     z-index: 99999;
-    box-shadow: 0 16px 48px rgba(0,0,0,0.5);
-    color: #fff;
+    box-shadow: 0 16px 48px var(--shadow-scrolled);
+    color: var(--text-primary);
     pointer-events: auto;
     min-width: 300px;
     max-width: 500px;
@@ -804,7 +1283,7 @@ th[data-tooltip] { cursor: pointer; }
     right: 0.5em;
     background: none;
     border: none;
-    color: #888;
+    color: var(--text-secondary);
     font-size: 1.25rem;
     cursor: pointer;
     padding: 0.25em 0.5em;
@@ -813,12 +1292,12 @@ th[data-tooltip] { cursor: pointer; }
     transition: color 0.15s, background 0.15s;
 }
 .popup-close:hover {
-    color: #fff;
-    background: rgba(255,255,255,0.1);
+    color: var(--text-primary);
+    background: var(--bg-card-hover);
 }
 .match-info-popup .popup-header {
     font-weight: 600;
-    color: #4facfe;
+    color: var(--accent-blue);
     margin-bottom: 0.75em;
     font-size: 0.85rem;
     text-transform: uppercase;
@@ -826,50 +1305,74 @@ th[data-tooltip] { cursor: pointer; }
     padding-right: 2em;
 }
 .match-info-popup .popup-row {
-    display: flex;
-    margin-bottom: 0.4em;
+    display: grid;
+    grid-template-columns: 92px minmax(0, 1fr);
+    column-gap: 0.5em;
+    align-items: center;
+    padding-top: 2px;
+    padding-bottom: 2px;
+    margin-bottom: 0;
 }
 .match-info-popup .popup-row:last-child {
     margin-bottom: 0;
 }
 .match-info-popup .popup-label {
-    color: #999;
-    min-width: 70px;
+    color: var(--text-light);
+    font-size: 0.9rem;
+    line-height: 1.25;
+    display: flex;
+    align-items: center;
     flex-shrink: 0;
-    margin-right: 0.5em;
 }
 .match-info-popup .popup-value {
-    color: #fff;
-    font-family: 'SF Mono', Monaco, 'Cascadia Code', monospace;
+    color: var(--text-primary);
+    font-family: inherit;
     font-size: 0.9rem;
-    word-break: break-all;
+    line-height: 1.25;
+    min-width: 0;
+    display: flex;
+    align-items: center;
+    word-break: break-word;
 }
 .match-info-popup .popup-value.source {
     font-family: inherit;
-    color: #aaa;
+    color: var(--text-secondary);
 }
 .match-info-popup .popup-tags-section .popup-value {
     display: flex;
     flex-direction: column;
-    gap: 0.3em;
+    gap: 0.45em;
 }
 .match-info-popup .popup-tag-item {
     display: flex;
-    flex-direction: column;
-    gap: 0.1em;
+    align-items: center;
+    gap: 0.5em;
+    flex-wrap: wrap;
 }
 .match-info-popup .popup-tag-name {
-    color: #fff;
+    color: var(--text-primary);
     font-weight: 500;
 }
+.match-info-popup .popup-tag-badge {
+    color: var(--accent-yellow);
+    margin-right: 0;
+    margin-bottom: 0;
+    cursor: default;
+}
 .match-info-popup .popup-tag-source {
-    color: #888;
+    color: var(--text-muted);
     font-size: 0.85em;
     font-family: inherit;
 }
+.match-info-popup .popup-tag-row .popup-value {
+    display: flex;
+    align-items: center;
+    gap: 0.35em;
+    flex-wrap: wrap;
+}
 .match-info-popup .popup-explanation {
     background: rgba(79, 172, 254, 0.15);
-    color: #4facfe;
+    color: var(--accent-blue);
     padding: 0.75em 1em;
     border-radius: 6px;
     margin-bottom: 1em;
@@ -886,29 +1389,32 @@ th[data-tooltip] { cursor: pointer; }
     font-size: 0.75rem;
     text-transform: uppercase;
     letter-spacing: 0.5px;
-    color: #888;
+    color: var(--text-muted);
     margin-bottom: 0.4em;
 }
 .match-info-popup .popup-code {
     font-family: 'SF Mono', Monaco, 'Cascadia Code', monospace;
     font-size: 0.85rem;
-    background: rgba(255, 255, 255, 0.08);
+    background: var(--bg-code);
     padding: 0.6em 0.8em;
     border-radius: 4px;
-    color: #ddd;
-    word-break: break-all;
+    color: var(--text-primary);
+    max-width: 100%;
+    white-space: pre-wrap;
+    overflow-wrap: anywhere;
+    word-break: break-word;
 }
-.match-info-popup .popup-source {
-    font-size: 0.8rem;
-    color: #888;
-    border-top: 1px solid #333;
+.match-info-popup .popup-view-section {
+    border-top: 1px solid var(--border-light);
     padding-top: 0.75em;
     margin-top: 0.75em;
 }
-/* Light mode adjustments */
-[data-theme="light"] .match-info-popup {
-    background: #222;
-    border-color: #444;
+.match-info-popup .popup-source {
+    font-size: 0.8rem;
+    color: var(--text-muted);
+    border-top: 1px solid var(--border-light);
+    padding-top: 0.75em;
+    margin-top: 0.75em;
 }
 .txn-row {
     background: var(--bg-txn-row);
@@ -923,37 +1429,45 @@ th[data-tooltip] { cursor: pointer; }
     border-bottom: none;
 }
 .txn-row td:first-child {
-    padding-left: 2rem;
+    padding-left: 0;
 }
 .txn-detail {
     display: grid;
-    grid-template-columns: 2rem 3.5rem 1fr auto 4rem;
+    --txn-extra-col: 2.1rem;
+    grid-template-columns: var(--txn-extra-col) var(--txn-date-col, 7.25rem) var(--txn-account-col, 11.5rem) minmax(0, 1fr) auto var(--txn-amount-col, 12ch);
     align-items: center;
     justify-items: start;
-    gap: 0.3rem;
+    column-gap: 0.3rem;
+    row-gap: 0.2rem;
 }
 .txn-detail:not(.has-extra)::before {
     content: '';
-    width: 2rem;
+    width: var(--txn-extra-col);
 }
 .txn-date {
     color: var(--text-muted);
     text-align: left;
+    white-space: nowrap;
+}
+.txn-account {
+    justify-self: stretch;
+    white-space: nowrap;
+    width: var(--txn-account-col, 11.5rem);
+    display: flex;
+    justify-content: center;
 }
 .txn-desc {
-    display: flex;
-    align-items: center;
-    gap: 0.3rem;
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
+    display: block;
+    white-space: normal;
+    overflow-wrap: anywhere;
     min-width: 0;
     justify-self: start;
     width: 100%;
+    text-align: left;
 }
 .txn-desc > span:last-child {
-    overflow: hidden;
-    text-overflow: ellipsis;
+    display: block;
+    text-align: left;
 }
 .txn-desc .search-highlight {
     background: rgba(255, 200, 0, 0.4);
@@ -966,21 +1480,32 @@ th[data-tooltip] { cursor: pointer; }
     font-family: monospace;
     text-align: right;
     justify-self: end;
+    width: var(--txn-amount-col, 12ch);
+    min-width: var(--txn-amount-col, 12ch);
+    white-space: nowrap;
 }
 .txn-badges {
     display: flex;
     align-items: center;
     gap: 0.3rem;
     justify-self: end;
+    white-space: nowrap;
 }
 /* Extra fields trigger and popup */
 .extra-fields-trigger {
     position: relative;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
     font-size: 0.7rem;
+    line-height: 1.1;
     color: var(--accent-blue);
     cursor: pointer;
-    padding: 0.1rem 0.35rem;
-    border-radius: 3px;
+    padding: 0.15rem 0.35rem;
+    min-width: 1.75rem;
+    margin-left: 0.3rem;
+    border: 1px solid rgba(79, 172, 254, 0.18);
+    border-radius: 4px;
     background: rgba(79, 172, 254, 0.15);
     font-weight: 600;
 }
@@ -1039,7 +1564,7 @@ th[data-tooltip] { cursor: pointer; }
     font-size: 0.7rem;
     padding: 0.1rem 0.4rem;
     border-radius: 3px;
-    margin-left: 0.5rem;
+    margin-left: 0;
     font-weight: bold;
 }
 .txn-source.amex {
@@ -1100,8 +1625,52 @@ th[data-tooltip] { cursor: pointer; }
     display: inline-block;
     transition: transform 0.2s;
 }
-.chart-section .section-header.collapsed .toggle {
-    transform: rotate(-90deg);
+/* Fix empty band when Trends is collapsed (header only) */
+.chart-section.collapsed {
+    padding-bottom: 0;
+}
+.chart-section.collapsed .section-header {
+    margin-bottom: 0;
+}
+
+/* Transaction Details container (wraps the view toggle + category collapsers) */
+.details-section {
+    background: var(--bg-card);
+    border-radius: 16px;
+    padding: 1.5rem;
+    margin-bottom: 2rem;
+    transition: padding 0.3s ease;
+}
+.details-section > .section-header {
+    cursor: pointer;
+    margin: -1.5rem -1.5rem 0.75rem -1.5rem;
+    padding: 1rem 1.5rem;
+    border-radius: 16px 16px 0 0;
+}
+.details-section > .section-header:hover {
+    background: var(--bg-card-hover);
+}
+.details-section > .section-header .header-count {
+    font-size: 0.85rem;
+    color: var(--text-muted);
+    font-weight: 400;
+}
+.details-section.collapsed {
+    padding-bottom: 0;
+}
+.details-section.collapsed > .section-header {
+    margin-bottom: 0;
+    border-radius: 16px;
+}
+.details-body {
+    transition: max-height 0.4s ease-out, opacity 0.3s ease-out;
+    max-height: 100000px;
+    opacity: 1;
+}
+.details-section.collapsed .details-body {
+    overflow: hidden;
+    max-height: 0;
+    opacity: 0;
 }
 .charts-grid {
     display: grid;
@@ -1115,6 +1684,9 @@ th[data-tooltip] { cursor: pointer; }
 }
 .chart-container {
     position: relative;
+    /* min-width: 0 lets grid tracks shrink below the rendered canvas width;
+       the default min-width: auto locks the grid open and clips charts on re-widen */
+    min-width: 0;
     background: var(--bg-table);
     border-radius: 12px;
     padding: 1.5rem;
@@ -1185,123 +1757,10 @@ footer {
     color: var(--text-dim);
     font-size: 0.85rem;
 }
-@keyframes fadeIn {
-    from { opacity: 0; transform: translateY(10px); }
-    to { opacity: 1; transform: translateY(0); }
-}
-section {
-    animation: fadeIn 0.4s ease-out forwards;
-}
-section:nth-child(2) { animation-delay: 0.1s; }
-section:nth-child(3) { animation-delay: 0.2s; }
-section:nth-child(4) { animation-delay: 0.3s; }
-section:nth-child(5) { animation-delay: 0.4s; }
-
 /* Click-to-filter on cells */
 .clickable { cursor: pointer; }
 .clickable:hover { text-decoration: underline; color: var(--accent-blue); }
 .clickable .chevron { text-decoration: none !important; display: inline-block; }
-
-/* Help/Guide section - Compact inline design */
-.help-section {
-    background: var(--bg-help);
-    border: 1px solid var(--border-help);
-    border-radius: 12px;
-    margin-bottom: 1.5rem;
-}
-.help-section-header {
-    padding: 0.75rem 1rem;
-    cursor: pointer;
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    transition: background 0.2s;
-}
-.help-section-header:hover {
-    background: var(--bg-table);
-}
-.help-section-header h3 {
-    font-size: 0.8rem;
-    font-weight: 500;
-    color: var(--text-secondary);
-    margin: 0;
-}
-.help-section-header .toggle {
-    color: var(--text-muted);
-    font-size: 0.7rem;
-    transition: transform 0.2s;
-}
-.help-section.collapsed .help-section-header .toggle {
-    transform: rotate(-90deg);
-}
-.help-section-content {
-    padding: 0.75rem 1rem 1rem;
-    border-top: 1px solid var(--border-table);
-    display: grid;
-    grid-template-columns: auto 1fr;
-    gap: 0.4rem 1rem;
-    font-size: 0.75rem;
-    color: var(--text-secondary);
-    align-items: baseline;
-}
-.help-section.collapsed .help-section-content {
-    display: none;
-}
-.help-section-content .label {
-    color: var(--text-muted);
-    font-weight: 500;
-    white-space: nowrap;
-}
-.help-section-content .value {
-    line-height: 1.5;
-}
-.help-section-content .badge {
-    margin-right: 0.15rem;
-}
-.help-section-content code {
-    background: var(--bg-code);
-    padding: 0.1rem 0.35rem;
-    border-radius: 3px;
-    font-size: 0.7rem;
-    color: var(--accent-blue);
-}
-.help-section-content strong {
-    color: var(--text-lighter);
-    font-weight: 500;
-}
-
-/* ============================================================
-   EXCLUDED TRANSACTIONS SECTION
-   ============================================================ */
-
-.excluded-note {
-    color: var(--accent-blue);
-    font-style: normal;
-    border-top: 1px dashed var(--border-light);
-    padding-top: 0.5rem;
-    margin-top: 0.5rem;
-    border-radius: 4px;
-    transition: all 0.2s ease;
-    white-space: nowrap;
-    gap: 0.5rem;
-}
-.excluded-note:hover {
-    color: var(--accent-blue-light);
-    background: rgba(79, 172, 254, 0.1);
-    margin: 0.5rem -0.5rem 0;
-    padding: 0.5rem;
-}
-.excluded-note:active {
-    transform: scale(0.98);
-}
-.excluded-note .name::before {
-    content: '👁 ';
-}
-.excluded-note .name::after {
-    content: ' ▼';
-    font-size: 0.7em;
-    opacity: 0.7;
-}
 
 /* Cash Flow Card */
 .card.cashflow {
@@ -1418,11 +1877,47 @@ section:nth-child(5) { animation-delay: 0.4s; }
 /* View Toggle (By Category / By View) */
 .view-toggle {
     display: flex;
-    justify-content: center;
+    flex-wrap: wrap;
+    justify-content: space-between;
+    align-items: center;
     gap: 0.5rem;
     margin-bottom: 1.5rem;
 }
+/* Two groups: view modes (left) and actions (right). space-between spreads them
+   to opposite ends on one line; when the row wraps on narrow/mobile widths, each
+   group drops to its own line, left-aligned. */
+.view-modes,
+.toggle-actions {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.5rem;
+}
+.icon-btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.4rem;
+    height: 34px;
+    min-width: 34px;
+    padding: 0 0.85rem;
+    border-radius: 8px;
+    border: 1px solid var(--border-medium);
+    background: var(--bg-card);
+    color: var(--text-secondary);
+    font-size: 0.9rem;
+    font-weight: 500;
+    cursor: pointer;
+    transition: all 0.2s;
+}
+.icon-btn:hover {
+    background: var(--bg-card-hover);
+    border-color: var(--accent-blue);
+    color: var(--text-primary);
+}
+.icon-btn svg { width: 16px; height: 16px; display: block; }
 .view-toggle button {
+    height: 34px;
     padding: 0.5rem 1.25rem;
     border-radius: 8px;
     border: 1px solid var(--border-medium);
@@ -1447,5 +1942,41 @@ section:nth-child(5) { animation-delay: 0.4s; }
     background: var(--accent-negative);
     border-color: var(--accent-negative);
 }
-
-
+.negatives-badge {
+    display: inline-block;
+    margin-left: 0.4rem;
+    padding: 0.05rem 0.4rem;
+    border-radius: 999px;
+    background: var(--accent-red);
+    color: white;
+    font-size: 0.75rem;
+    font-weight: 700;
+    line-height: 1.4;
+    vertical-align: middle;
+}
+/* Mobile: compact the view toggle so it fits two rows — view modes on the
+   first, negatives + collapse on the second. The collapse button goes
+   icon-only (its title tooltip still names the action) to make room. */
+@media (max-width: 800px) {
+    .collapse-all-btn span {
+        display: none;
+    }
+}
+@media (max-width: 640px) {
+    .view-toggle,
+    .view-modes,
+    .toggle-actions {
+        gap: 0.4rem;
+    }
+    .view-toggle button,
+    .icon-btn {
+        height: 32px;
+    }
+    .view-toggle button {
+        padding: 0.45rem 0.5rem;
+        font-size: 0.82rem;
+    }
+    .icon-btn {
+        padding: 0 0.5rem;
+    }
+}

--- a/src/tally/spending_report.css
+++ b/src/tally/spending_report.css
@@ -134,6 +134,20 @@ body {
 
 [v-cloak] { display: none; }
 
+/* Text carried to screen readers only - for state a sighted user reads from
+   a purely visual cue, such as the year tab's pending-months dot. */
+.sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+}
+
 body.app-initializing #app {
     opacity: 0;
     pointer-events: none;
@@ -442,6 +456,10 @@ h1 {
     cursor: pointer;
     color: var(--text-secondary);
     border: 1px solid transparent;
+    /* A <button> for keyboard access; these keep it looking like the tab it is. */
+    background: transparent;
+    font-family: inherit;
+    line-height: inherit;
 }
 .date-popover .year-tab.active {
     background: var(--bg-card-hover);
@@ -495,6 +513,10 @@ h1 {
     font-size: 0.82rem;
     cursor: pointer;
     transition: all 0.15s;
+    /* A <button> for keyboard access; keeps the grid cell's own look. */
+    font-family: inherit;
+    line-height: inherit;
+    width: 100%;
 }
 .date-popover .month-cell:hover { border-color: var(--accent-blue); }
 .date-popover .month-cell.selected {

--- a/src/tally/spending_report.html
+++ b/src/tally/spending_report.html
@@ -25,7 +25,7 @@
                 <h1 data-testid="report-title">{{ title }}</h1>
                 <p class="subtitle">{{ subtitle }}</p>
                 <div class="header-actions">
-                    <button class="reset-settings-btn" data-testid="reset-settings" @click="resetUiSettings" title="Reset Layout Settings">↺</button>
+                    <button class="reset-settings-btn" data-testid="reset-settings" @click="resetUiSettings" title="Reset Layout Settings" aria-label="Reset layout settings">↺</button>
                     <button class="theme-toggle" data-testid="theme-toggle" @click="toggleTheme" :title="isDarkTheme ? 'Switch to light mode' : 'Switch to dark mode'">
                         {{ isDarkTheme ? '☀️' : '🌙' }}
                     </button>
@@ -73,21 +73,25 @@
                         </div>
                         <div class="popover-divider"></div>
                         <div class="year-tabs" data-testid="date-year-tabs">
-                            <div v-for="year in yearTabs" :key="year" class="year-tab"
-                                 :class="{ active: year === activeYearTab }"
-                                 :data-testid="'date-year-tab-' + year"
-                                 @click="activeYearTab = year">
+                            <button type="button" v-for="year in yearTabs" :key="year" class="year-tab"
+                                    :class="{ active: year === activeYearTab }"
+                                    :data-testid="'date-year-tab-' + year"
+                                    :aria-pressed="year === activeYearTab"
+                                    @click="activeYearTab = year">
                                 <span>{{ year }}</span>
-                                <span v-if="yearTabHasPending(year)" class="dot"></span>
-                            </div>
+                                <span v-if="yearTabHasPending(year)" class="dot" aria-hidden="true"></span>
+                                <span v-if="yearTabHasPending(year)" class="sr-only">has selected months</span>
+                            </button>
                             <button type="button" class="link-btn" data-testid="date-clear-months"
                                     @click="clearPendingMonths">Clear</button>
                         </div>
                         <div class="month-grid month-grid-3col" data-testid="date-month-grid">
-                            <div v-for="m in activeYearMonths" :key="m.key" class="month-cell"
-                                 :class="{ selected: pendingMonths.has(m.key) }"
-                                 :data-testid="'date-month-cell-' + m.key"
-                                 @click="toggleDateItem({ type: 'month', key: m.key })">{{ m.label.split(' ')[0] }}</div>
+                            <button type="button" v-for="m in activeYearMonths" :key="m.key" class="month-cell"
+                                    :class="{ selected: pendingMonths.has(m.key) }"
+                                    :data-testid="'date-month-cell-' + m.key"
+                                    :aria-pressed="pendingMonths.has(m.key)"
+                                    :aria-label="m.label"
+                                    @click="toggleDateItem({ type: 'month', key: m.key })">{{ m.label.split(' ')[0] }}</button>
                         </div>
                         <div class="popover-divider"></div>
                         <div class="daterange-row">
@@ -293,6 +297,7 @@
                     :title="section.title"
                     :items="Object.values(section.filteredMerchants)"
                     :total-amount="section.filteredTotal"
+                    :spending-amount="section.filteredSpending"
                     :category-total="section.filteredTotal"
                     :grand-total="grandTotal"
                     :gross-spending="grossSpending"
@@ -328,6 +333,7 @@
                     :title="categoryName"
                     :items="groupByMode === 'subcategory' ? category.sortedSubcategories : category.sortedMerchants"
                     :total-amount="category.filteredTotal"
+                    :spending-amount="category.filteredSpending"
                     :category-total="category.filteredTotal"
                     :grand-total="grandTotal"
                     :gross-spending="grossSpending"

--- a/src/tally/spending_report.html
+++ b/src/tally/spending_report.html
@@ -3,19 +3,33 @@
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>Financial Report</title>
+    <title>__REPORT_TITLE__</title>
     <style>/* CSS_PLACEHOLDER */</style>
 </head>
-<body>
-    <div id="app">
+<body class="app-initializing">
+    <div id="app-loading" class="app-loading-shell" aria-live="polite" aria-busy="true">
+        <div class="container">
+            <header class="loading-header">
+                <h1 class="loading-title">__REPORT_TITLE__</h1>
+                <p class="loading-subtitle">Preparing your spending analysis...</p>
+            </header>
+            <div class="loading-progress-wrap" role="status" aria-label="Loading report">
+                <div class="loading-progress-bar"></div>
+            </div>
+        </div>
+    </div>
+    <div id="app" v-cloak>
         <div class="container">
             <!-- Header -->
             <header>
                 <h1 data-testid="report-title">{{ title }}</h1>
                 <p class="subtitle">{{ subtitle }}</p>
-                <button class="theme-toggle" data-testid="theme-toggle" @click="toggleTheme" :title="isDarkTheme ? 'Switch to light mode' : 'Switch to dark mode'">
-                    {{ isDarkTheme ? '☀️' : '🌙' }}
-                </button>
+                <div class="header-actions">
+                    <button class="reset-settings-btn" data-testid="reset-settings" @click="resetUiSettings" title="Reset Layout Settings">↺</button>
+                    <button class="theme-toggle" data-testid="theme-toggle" @click="toggleTheme" :title="isDarkTheme ? 'Switch to light mode' : 'Switch to dark mode'">
+                        {{ isDarkTheme ? '☀️' : '🌙' }}
+                    </button>
+                </div>
             </header>
 
             <!-- Search & Filters -->
@@ -39,12 +53,68 @@
                         </div>
                     </div>
                 </div>
-                <select class="date-range-select" @change="addMonthFilter($event.target.value); $event.target.value = ''">
-                    <option value="">+ Date filter</option>
-                    <optgroup label="Individual Months">
-                        <option v-for="m in availableMonths" :key="m.key" :value="m.key">{{ m.label }}</option>
-                    </optgroup>
-                </select>
+                <div class="date-filter-wrap">
+                    <button type="button" class="date-range-select date-filter-trigger"
+                            :class="{ open: datePopoverOpen }"
+                            data-testid="date-filter-trigger"
+                            @click.stop="toggleDatePopover">📅 Date filter <span class="chev">▾</span></button>
+                    <div class="date-popover" v-if="datePopoverOpen" data-testid="date-popover" @click.stop>
+                        <div class="quick-grid quick-grid-3col" data-testid="date-this-row">
+                            <button v-for="item in thisLastPresets.thisRow" :key="item.key" type="button"
+                                    class="quick-pill" :class="{ active: isDateItemActive(item) }"
+                                    :data-testid="'date-preset-' + item.label.toLowerCase().replace(/ /g, '-')"
+                                    @click="toggleDateItem(item)">{{ item.label }}</button>
+                        </div>
+                        <div class="quick-grid quick-grid-3col" data-testid="date-last-row">
+                            <button v-for="item in thisLastPresets.lastRow" :key="item.key" type="button"
+                                    class="quick-pill" :class="{ active: isDateItemActive(item) }"
+                                    :data-testid="'date-preset-' + item.label.toLowerCase().replace(/ /g, '-')"
+                                    @click="toggleDateItem(item)">{{ item.label }}</button>
+                        </div>
+                        <div class="popover-divider"></div>
+                        <div class="year-tabs" data-testid="date-year-tabs">
+                            <div v-for="year in yearTabs" :key="year" class="year-tab"
+                                 :class="{ active: year === activeYearTab }"
+                                 :data-testid="'date-year-tab-' + year"
+                                 @click="activeYearTab = year">
+                                <span>{{ year }}</span>
+                                <span v-if="yearTabHasPending(year)" class="dot"></span>
+                            </div>
+                            <button type="button" class="link-btn" data-testid="date-clear-months"
+                                    @click="clearPendingMonths">Clear</button>
+                        </div>
+                        <div class="month-grid month-grid-3col" data-testid="date-month-grid">
+                            <div v-for="m in activeYearMonths" :key="m.key" class="month-cell"
+                                 :class="{ selected: pendingMonths.has(m.key) }"
+                                 :data-testid="'date-month-cell-' + m.key"
+                                 @click="toggleDateItem({ type: 'month', key: m.key })">{{ m.label.split(' ')[0] }}</div>
+                        </div>
+                        <div class="popover-divider"></div>
+                        <div class="daterange-row">
+                            <div class="date-input-wrap">
+                                <label>Start</label>
+                                <drill-calendar :model-value="customStart"
+                                                @update:model-value="customStart = $event"
+                                                testid-prefix="date-start"
+                                                placeholder="e.g. 3/15/2026"></drill-calendar>
+                            </div>
+                            <div class="date-input-wrap">
+                                <label>End</label>
+                                <drill-calendar :model-value="customEnd"
+                                                @update:model-value="customEnd = $event"
+                                                testid-prefix="date-end"
+                                                placeholder="e.g. 7/7/2026"
+                                                :align-right="true"></drill-calendar>
+                            </div>
+                        </div>
+                        <div class="popover-footer">
+                            <button type="button" class="link-btn link-danger" data-testid="date-clear-all"
+                                    @click="clearAllDateFilters">Clear all filters</button>
+                            <button type="button" class="apply-btn" data-testid="date-apply"
+                                    @click="applyDateFilters">Apply</button>
+                        </div>
+                    </div>
+                </div>
                 <div class="filter-chips" v-if="activeFilters.length > 0" data-testid="filter-chips">
                     <div v-for="(filter, index) in activeFilters"
                          :key="index"
@@ -130,7 +200,7 @@
             </div>
 
             <!-- Charts Section -->
-            <div class="chart-section">
+            <div class="chart-section" :class="{ collapsed: chartsCollapsed }">
                 <div class="section-header" @click="chartsCollapsed = !chartsCollapsed">
                     <h2>
                         <span class="toggle">{{ chartsCollapsed ? '▶' : '▼' }}</span>
@@ -140,20 +210,20 @@
                 <div class="section-content" :class="{ collapsed: chartsCollapsed }">
                     <div class="charts-grid">
                         <div class="chart-container">
-                            <h3>Monthly Trend</h3>
+                            <h3>Cash Flow Trend</h3>
                             <div class="chart-wrapper">
                                 <canvas ref="monthlyChart"></canvas>
                             </div>
                         </div>
                         <div class="chart-container">
-                            <h3>By Category</h3>
+                            <h3>Spending by Category</h3>
                             <div class="chart-wrapper">
                                 <canvas ref="categoryPieChart"></canvas>
                             </div>
                         </div>
                     </div>
                     <div class="chart-container" style="margin-top: 2rem;">
-                        <h3>Category Trends by Month</h3>
+                        <h3>Spending by Category Trend</h3>
                         <div class="chart-wrapper" style="height: 350px;">
                             <canvas ref="categoryByMonthChart"></canvas>
                         </div>
@@ -161,28 +231,57 @@
                 </div>
             </div>
 
-            <!-- Unified View Toggle -->
+            <!-- Transaction Details container -->
+            <div class="details-section" :class="{ collapsed: detailsCollapsed }">
+                <div class="section-header" @click="detailsCollapsed = !detailsCollapsed">
+                    <h2>
+                        <span class="toggle">{{ detailsCollapsed ? '▶' : '▼' }}</span>
+                        Transaction Details
+                    </h2>
+                    <span class="header-count" data-testid="details-summary">{{ detailsSummary }}</span>
+                </div>
+                <div class="details-body">
+            <!-- Unified View Toggle. Two groups so they wrap cleanly on mobile:
+                 view modes stay on one line, negatives + collapse drop to the next. -->
             <div class="view-toggle">
-                <button :class="{ active: currentView === 'category' && groupByMode === 'merchant' }"
-                        @click="currentView = 'category'; groupByMode = 'merchant'">
-                    Merchant
-                </button>
-                <button :class="{ active: currentView === 'category' && groupByMode === 'subcategory' }"
-                        @click="currentView = 'category'; groupByMode = 'subcategory'">
-                    Subcategory
-                </button>
-                <button v-if="hasSections"
-                        :class="{ active: currentView === 'section' }"
-                        @click="currentView = 'section'">
-                    View
-                </button>
-                <button v-if="currentView === 'category' || hasSections"
-                        class="toggle-negatives"
-                        :class="{ active: includeNegativeTotals }"
-                        :title="includeNegativeTotals ? 'Exclude categories and merchants with net negative totals' : 'Include categories and merchants with net negative totals'"
-                        @click="includeNegativeTotals = !includeNegativeTotals">
-                    {{ includeNegativeTotals ? 'Exclude Negatives' : 'Include Negatives' }}
-                </button>
+                <div class="view-modes">
+                    <button :class="{ active: currentView === 'category' && groupByMode === 'merchant' }"
+                            @click="currentView = 'category'; groupByMode = 'merchant'">
+                        Merchant
+                    </button>
+                    <button :class="{ active: currentView === 'category' && groupByMode === 'subcategory' }"
+                            @click="currentView = 'category'; groupByMode = 'subcategory'">
+                        Subcategory
+                    </button>
+                    <button v-if="hasSections"
+                            :class="{ active: currentView === 'section' }"
+                            @click="currentView = 'section'">
+                        View
+                    </button>
+                </div>
+                <div class="toggle-actions">
+                    <button v-if="(currentView === 'category' || hasSections) && negativeTotalsCount > 0"
+                            class="toggle-negatives"
+                            :class="{ active: includeNegativeTotals }"
+                            :title="includeNegativeTotals ? 'Exclude categories and merchants with net negative totals' : 'Include categories and merchants with net negative totals'"
+                            @click="includeNegativeTotals = !includeNegativeTotals">
+                        {{ includeNegativeTotals ? 'Exclude Negatives' : 'Include Negatives' }}
+                        <span v-if="!includeNegativeTotals" class="negatives-badge">{{ negativeTotalsCount > 99 ? '99+' : negativeTotalsCount }}</span>
+                    </button>
+                    <button class="icon-btn collapse-all-btn" data-testid="collapse-all-toggle" :title="allCollapsed ? 'Expand all categories' : 'Collapse all categories'" @click="toggleAllSections()">
+                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                            <template v-if="allCollapsed">
+                                <polyline points="7 13 12 18 17 13"></polyline>
+                                <polyline points="7 6 12 11 17 6"></polyline>
+                            </template>
+                            <template v-else>
+                                <polyline points="17 11 12 6 7 11"></polyline>
+                                <polyline points="17 18 12 13 7 18"></polyline>
+                            </template>
+                        </svg>
+                        <span>{{ allCollapsed ? 'Expand all' : 'Collapse all' }}</span>
+                    </button>
+                </div>
             </div>
 
             <!-- Section View -->
@@ -210,19 +309,24 @@
                     :format-date="formatDate"
                     :format-pct="formatPct"
                     :add-filter="addFilter"
+                    :is-include-filter-active="isIncludeFilterActive"
+                    :toggle-include-filter="toggleIncludeFilter"
                     :highlight-description="highlightDescription"
                     :tag-color="tagColor"
                 ></merchant-section>
             </template>
 
-            <!-- Category View - Grouped by Merchant -->
-            <template v-if="currentView === 'category' && groupByMode === 'merchant'">
+            <!-- Category View - one keyed v-for for both merchant & subcategory grouping.
+                 Both groupings key sections by the same category names, so a single
+                 v-for lets Vue patch <section> nodes in place across a groupByMode
+                 toggle instead of tearing them down and remounting them. -->
+            <template v-if="currentView === 'category'">
                 <merchant-section
-                    v-for="(category, categoryName) in positiveCategoryView"
+                    v-for="(category, categoryName) in (groupByMode === 'subcategory' ? subcategoryGroupedView : positiveCategoryView)"
                     :key="categoryName"
                     :section-key="'cat:' + categoryName"
                     :title="categoryName"
-                    :items="category.sortedMerchants"
+                    :items="groupByMode === 'subcategory' ? category.sortedSubcategories : category.sortedMerchants"
                     :total-amount="category.filteredTotal"
                     :category-total="category.filteredTotal"
                     :grand-total="grandTotal"
@@ -234,6 +338,7 @@
                     :num-months="numFilteredMonths"
                     :header-color="categoryColorMap[categoryName]"
                     :category-mode="true"
+                    :subcategory-mode="groupByMode === 'subcategory'"
                     :collapsed-sections="collapsedSections"
                     :sort-config="sortConfig"
                     :expanded-items="expandedMerchants"
@@ -244,45 +349,14 @@
                     :format-date="formatDate"
                     :format-pct="formatPct"
                     :add-filter="addFilter"
+                    :is-include-filter-active="isIncludeFilterActive"
+                    :toggle-include-filter="toggleIncludeFilter"
                     :highlight-description="highlightDescription"
                     :tag-color="tagColor"
                 ></merchant-section>
             </template>
-
-            <!-- Category View - Grouped by Subcategory -->
-            <template v-if="currentView === 'category' && groupByMode === 'subcategory'">
-                <merchant-section
-                    v-for="(category, categoryName) in subcategoryGroupedView"
-                    :key="categoryName"
-                    :section-key="'cat:' + categoryName"
-                    :title="categoryName"
-                    :items="category.sortedSubcategories"
-                    :total-amount="category.filteredTotal"
-                    :category-total="category.filteredTotal"
-                    :grand-total="grandTotal"
-                    :gross-spending="grossSpending"
-                    :total-unfiltered-spending="spendingTotal"
-                    :income-total="incomeTotal"
-                    :investment-total="investmentTotal"
-                    :type-totals="category.typeTotals"
-                    :num-months="numFilteredMonths"
-                    :header-color="categoryColorMap[categoryName]"
-                    :category-mode="true"
-                    :subcategory-mode="true"
-                    :collapsed-sections="collapsedSections"
-                    :sort-config="sortConfig"
-                    :expanded-items="expandedMerchants"
-                    :extra-field-matches="extraFieldMatches"
-                    :toggle-section="toggleSection"
-                    :toggle-sort="toggleSort"
-                    :format-currency="formatCurrency"
-                    :format-date="formatDate"
-                    :format-pct="formatPct"
-                    :add-filter="addFilter"
-                    :highlight-description="highlightDescription"
-                    :tag-color="tagColor"
-                ></merchant-section>
-            </template>
+                </div><!-- /.details-body -->
+            </div><!-- /.details-section -->
 
             <!-- Footer -->
             <footer>

--- a/src/tally/spending_report.js
+++ b/src/tally/spending_report.js
@@ -224,13 +224,29 @@ function dateRangeDisplayText(text) {
     return startPart + ' – ' + MONTH_NAMES_SHORT[parseInt(bp[1], 10) - 1] + ' ' + parseInt(bp[2], 10) + ', ' + bp[0];
 }
 
+// A y/m/d triple that a calendar actually has. The regexes below only prove
+// the shape, so 2/31/2026, 13/1/2026 and 99/99/2026 all reach here looking
+// well-formed; without this they become chips that can never match a
+// transaction.
+function isRealDate(dt) {
+    if (!dt || dt.m < 1 || dt.m > 12 || dt.d < 1) return false;
+    // Day 0 of the next month is the last day of this one.
+    return dt.d <= new Date(dt.y, dt.m, 0).getDate();
+}
+
 function parseTypedDate(str) {
     str = (str || '').trim();
     if (!str) return null;
     const m1 = str.match(/^(\d{4})-(\d{1,2})-(\d{1,2})$/);
-    if (m1) return { y: +m1[1], m: +m1[2], d: +m1[3] };
+    if (m1) {
+        const dt = { y: +m1[1], m: +m1[2], d: +m1[3] };
+        return isRealDate(dt) ? dt : null;
+    }
     const m2 = str.match(/^(\d{1,2})\/(\d{1,2})\/(\d{4})$/);
-    if (m2) return { y: +m2[3], m: +m2[1], d: +m2[2] };
+    if (m2) {
+        const dt = { y: +m2[3], m: +m2[1], d: +m2[2] };
+        return isRealDate(dt) ? dt : null;
+    }
     const d = new Date(str);
     if (!isNaN(d.getTime())) return { y: d.getFullYear(), m: d.getMonth() + 1, d: d.getDate() };
     return null;
@@ -258,6 +274,9 @@ const MerchantSection = defineComponent({
         // Subcategory mode: rows are subcategories, not merchants
         subcategoryMode: { type: Boolean, default: false },
         categoryTotal: { type: Number, default: 0 },
+        // Spending-only counterpart of totalAmount, for percentages taken
+        // against grossSpending (which excludes income/investment/transfers).
+        spendingAmount: { type: Number, default: 0 },
         grandTotal: { type: Number, default: 0 },
         grossSpending: { type: Number, default: 0 },
         totalUnfilteredSpending: { type: Number, default: 0 },
@@ -309,7 +328,7 @@ const MerchantSection = defineComponent({
                             <span v-if="typeTotals.income > 0 && incomeTotal > 0" class="income-pct">({{ formatPct(typeTotals.income, incomeTotal) }} income)</span>
                             <span v-if="typeTotals.investment > 0 && investmentTotal > 0" class="investment-pct">({{ formatPct(typeTotals.investment, investmentTotal) }} invest)</span>
                         </span>
-                        <span class="section-pct" v-else-if="grossSpending > 0">({{ formatPct(totalAmount, grossSpending) }})</span>
+                        <span class="section-pct" v-else-if="grossSpending > 0">({{ formatPct(spendingAmount, grossSpending) }})</span>
                     </template>
                     <template v-else>
                         <span v-if="showTotal" class="section-ytd credit-amount">+{{ formatCurrency(totalAmount) }}</span>
@@ -862,7 +881,11 @@ createApp({
         const spendingData = computed(() => window.spendingData || { sections: {}, numMonths: 12 });
 
         // Report title and subtitle
-        const title = computed(() => spendingData.value.title || 'Financial Report');
+        // report.py always resolves this, so the fallback only covers a
+        // hand-edited spending_data.js. Keep it identical to the Python
+        // default - two different fallbacks is what made the mounted app
+        // rename a report that the loading shell had already titled.
+        const title = computed(() => spendingData.value.title || 'Tally Spending Analysis');
         const subtitle = computed(() => {
             const data = spendingData.value;
             const sources = data.sources || [];
@@ -896,6 +919,19 @@ createApp({
 
             return ids;
         });
+
+        // Spending-only subtotal, on the same basis grossSpending uses: classify
+        // each transaction and keep the spending bucket, so income, investment
+        // and transfer amounts drop out instead of being raw-summed. Any
+        // percentage taken against grossSpending must use this rather than
+        // filteredTotal, or numerator and denominator disagree about what counts.
+        function spendingSubtotal(txns) {
+            let total = 0;
+            for (const t of txns || []) {
+                total += categorizeAmount(t.amount || 0, t.tags || []).spending;
+            }
+            return total;
+        }
 
         // Core filtering - returns sections with filtered merchants and transactions
         const filteredSections = computed(() => {
@@ -947,10 +983,12 @@ createApp({
             for (const [catName, category] of Object.entries(categoryView)) {
                 const filteredSubcategories = {};
                 let categoryTotal = 0;
+                let categorySpending = 0;
 
                 for (const [subcatName, subcat] of Object.entries(category.subcategories || {})) {
                     const filteredMerchants = {};
                     let subcatTotal = 0;
+                    let subcatSpending = 0;
 
                     for (const [merchantId, merchant] of Object.entries(subcat.merchants || {})) {
                         // Filter transactions
@@ -970,6 +1008,7 @@ createApp({
                                 filteredMonths: months.size
                             };
                             subcatTotal += filteredTotal;
+                            subcatSpending += spendingSubtotal(filteredTxns);
                         }
                     }
 
@@ -977,9 +1016,11 @@ createApp({
                         filteredSubcategories[subcatName] = {
                             ...subcat,
                             filteredMerchants,
-                            filteredTotal: subcatTotal
+                            filteredTotal: subcatTotal,
+                            filteredSpending: subcatSpending
                         };
                         categoryTotal += subcatTotal;
+                        categorySpending += subcatSpending;
                     }
                 }
 
@@ -987,7 +1028,8 @@ createApp({
                     result[catName] = {
                         ...category,
                         filteredSubcategories,
-                        filteredTotal: categoryTotal
+                        filteredTotal: categoryTotal,
+                        filteredSpending: categorySpending
                     };
                 }
             }
@@ -1225,6 +1267,7 @@ createApp({
             for (const [sectionId, section] of Object.entries(sections)) {
                 const filteredMerchants = {};
                 let sectionTotal = 0;
+                let sectionSpending = 0;
 
                 for (const [merchantId, merchant] of Object.entries(section.merchants || {})) {
                     // Filter transactions
@@ -1244,6 +1287,7 @@ createApp({
                             filteredMonths: months.size
                         };
                         sectionTotal += filteredTotal;
+                        sectionSpending += spendingSubtotal(filteredTxns);
                     }
                 }
 
@@ -1251,7 +1295,8 @@ createApp({
                     result[sectionId] = {
                         ...section,
                         filteredMerchants,
-                        filteredTotal: sectionTotal
+                        filteredTotal: sectionTotal,
+                        filteredSpending: sectionSpending
                     };
                 }
             }
@@ -1984,6 +2029,10 @@ createApp({
             pendingMonths.clear();
             let rangeChip = null;
             for (const f of activeFilters.value) {
+                // The popover edits include-mode date filters only. An excluded
+                // chip rehydrated here would come back out of applyDateFilters()
+                // as an inclusion, silently inverting what the user asked for.
+                if (f.mode !== 'include') continue;
                 if (f.type === 'month') {
                     if (f.text.includes('..')) expandMonthRange(f.text).forEach(k => pendingMonths.add(k));
                     else pendingMonths.add(f.text);
@@ -2026,7 +2075,11 @@ createApp({
         // Apply: re-aggregate pending months into the fewest chips, then append
         // the (independent) custom range. Existing date chips are replaced.
         function applyDateFilters() {
-            activeFilters.value = activeFilters.value.filter(f => filterCategory(f.type) !== 'date');
+            // Replace the include-mode date chips this popover owns; excluded
+            // date chips are not editable here, so they survive untouched.
+            activeFilters.value = activeFilters.value.filter(f =>
+                filterCategory(f.type) !== 'date' || f.mode !== 'include'
+            );
             aggregateMonthKeys([...pendingMonths]).forEach(entry =>
                 activeFilters.value.push(aggregateEntryToChip(entry))
             );
@@ -2240,21 +2293,50 @@ createApp({
             document.body.appendChild(txMeasureHost);
         }
 
+        // Rendered width depends only on the string - the measuring spans carry
+        // fixed classes - and the same dates, accounts and amounts repeat across
+        // thousands of transactions and across all three profiles. Uncached,
+        // every transaction forced three synchronous layouts, which stalls large
+        // reports. Cleared per recompute so a resize re-measures.
+        const txMeasureCache = { date: new Map(), account: new Map(), amount: new Map() };
+
+        function measureCachedPx(kind, key, measure) {
+            const cache = txMeasureCache[kind];
+            let px = cache.get(key);
+            if (px === undefined) {
+                px = measure();
+                cache.set(key, px);
+            }
+            return px;
+        }
+
+        function clearTxnMeasureCache() {
+            txMeasureCache.date.clear();
+            txMeasureCache.account.clear();
+            txMeasureCache.amount.clear();
+        }
+
         function measureTxnDatePx(label) {
-            txMeasureDateEl.textContent = label || '';
-            return Math.ceil(txMeasureDateEl.getBoundingClientRect().width);
+            return measureCachedPx('date', label || '', () => {
+                txMeasureDateEl.textContent = label || '';
+                return Math.ceil(txMeasureDateEl.getBoundingClientRect().width);
+            });
         }
 
         function measureTxnAmountPx(label) {
-            txMeasureAmountEl.textContent = label || '';
-            return Math.ceil(txMeasureAmountEl.getBoundingClientRect().width);
+            return measureCachedPx('amount', label || '', () => {
+                txMeasureAmountEl.textContent = label || '';
+                return Math.ceil(txMeasureAmountEl.getBoundingClientRect().width);
+            });
         }
 
         function measureTxnAccountPx(source) {
             if (!source) return 0;
-            txMeasureAccountEl.className = 'txn-source ' + source.toLowerCase();
-            txMeasureAccountEl.textContent = source;
-            return Math.ceil(txMeasureAccountEl.getBoundingClientRect().width);
+            return measureCachedPx('account', source, () => {
+                txMeasureAccountEl.className = 'txn-source ' + source.toLowerCase();
+                txMeasureAccountEl.textContent = source;
+                return Math.ceil(txMeasureAccountEl.getBoundingClientRect().width);
+            });
         }
 
         function formatTxnAmountLabel(txn) {
@@ -2307,6 +2389,9 @@ createApp({
         }
 
         function recomputeTxnColumnProfiles() {
+            // Font metrics can change with the viewport, so start each pass cold;
+            // within the pass the three modes share every measurement.
+            clearTxnMeasureCache();
             txColumnProfiles.merchant = measureTxnColumnsForMode('merchant');
             txColumnProfiles.subcategory = measureTxnColumnsForMode('subcategory');
             txColumnProfiles.section = hasSections.value ? measureTxnColumnsForMode('section') : txColumnProfiles.merchant;
@@ -2362,7 +2447,13 @@ createApp({
         }
 
         function expandMonthRange(rangeStr) {
-            const [start, end] = rangeStr.split('..');
+            const [start, end] = String(rangeStr).split('..');
+            // Both halves must be real YYYY-MM keys before we iterate. A
+            // hand-edited hash like '#+dr:garbage..garbage' otherwise walks
+            // 'garba' -> NaN-NaN, and 'NaN-NaN' <= 'garba' stays true forever,
+            // hanging the report while the array grows without bound.
+            const monthKey = /^\d{4}-(0[1-9]|1[0-2])$/;
+            if (!monthKey.test(start || '') || !monthKey.test(end || '')) return [];
             const months = [];
             let current = start;
             while (current <= end) {

--- a/src/tally/spending_report.js
+++ b/src/tally/spending_report.js
@@ -3,6 +3,18 @@
 
 const { createApp, ref, reactive, computed, watch, onMounted, nextTick, defineComponent } = Vue;
 
+function setAppInitializingState() {
+    document.body.classList.add('app-initializing');
+    document.body.classList.remove('app-ready');
+}
+
+function setAppReadyState() {
+    document.body.classList.remove('app-initializing');
+    document.body.classList.add('app-ready');
+}
+
+setAppInitializingState();
+
 // =============================================================================
 // TRANSACTION CLASSIFICATION - Mirrors Python classification.py
 // =============================================================================
@@ -87,6 +99,145 @@ function calculateCashFlow(income, spending, credits) {
 
 // =============================================================================
 
+// =============================================================================
+// DATE FILTER HELPERS (Month / Quarter / Year / Custom range)
+// =============================================================================
+
+const MONTH_NAMES_SHORT = ['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec'];
+const MONTH_NAMES_LONG = ['January','February','March','April','May','June','July','August','September','October','November','December'];
+
+function pad2(n) { return String(n).padStart(2, '0'); }
+function quarterOf(monthNum) { return Math.ceil(monthNum / 3); }
+
+// 'YYYY-MM' -> 'Mon YYYY'
+function monthKeyLabel(key) {
+    const parts = key.split('-');
+    return MONTH_NAMES_SHORT[parseInt(parts[1], 10) - 1] + ' ' + parts[0];
+}
+function quarterMonthKeys(year, q) {
+    const startM = (q - 1) * 3 + 1;
+    return [startM, startM + 1, startM + 2].map(m => year + '-' + pad2(m));
+}
+function yearMonthKeys(year) {
+    const out = [];
+    for (let m = 1; m <= 12; m++) out.push(year + '-' + pad2(m));
+    return out;
+}
+
+// Flatten a preset item ({type:'month'|'quarter'|'year', key}) to its
+// constituent calendar-month keys. This is the shared path that lets
+// quarter/year presets, individual month clicks, and aggregation all use one
+// coverage/toggle mechanism.
+function monthsForItem(item) {
+    if (item.type === 'month') return [item.key];
+    if (item.type === 'quarter') {
+        const parts = item.key.split('-Q');
+        return quarterMonthKeys(parseInt(parts[0], 10), parseInt(parts[1], 10));
+    }
+    if (item.type === 'year') return yearMonthKeys(parseInt(item.key, 10));
+    return [];
+}
+
+// Greedily compress a flat set of month keys into the fewest chips: any full
+// year first, then any full quarters remaining in that year, then whatever
+// individual months are left. Returns {type, key, label}[].
+function aggregateMonthKeys(monthKeys) {
+    const remaining = {};
+    monthKeys.forEach(k => { remaining[k] = true; });
+    const byYear = {};
+    monthKeys.forEach(k => { (byYear[k.slice(0, 4)] = byYear[k.slice(0, 4)] || []).push(k); });
+
+    const results = [];
+    Object.keys(byYear).sort().forEach(yearStr => {
+        const year = parseInt(yearStr, 10);
+        if (yearMonthKeys(year).every(k => remaining[k])) {
+            results.push({ type: 'year', key: yearStr, label: yearStr });
+            yearMonthKeys(year).forEach(k => delete remaining[k]);
+            return;
+        }
+        for (let q = 1; q <= 4; q++) {
+            const qMonths = quarterMonthKeys(year, q);
+            if (qMonths.every(k => remaining[k])) {
+                results.push({ type: 'quarter', key: yearStr + '-Q' + q, label: 'Q' + q + ' ' + yearStr });
+                qMonths.forEach(k => delete remaining[k]);
+            }
+        }
+    });
+    Object.keys(remaining).sort().forEach(k => {
+        results.push({ type: 'month', key: k, label: monthKeyLabel(k) });
+    });
+    return results;
+}
+
+// Chip type -> filter category. month/daterange share the 'date' category so
+// they OR together in passesFilters instead of AND-ing as separate types.
+function filterCategory(type) {
+    return (type === 'month' || type === 'daterange') ? 'date' : type;
+}
+
+// Convert an aggregated {type,key,label} entry into an activeFilters chip.
+// Quarter/year become 'YYYY-MM..YYYY-MM' range strings under the 'month' type
+// (reusing monthMatches), matching the chip data model in the plan.
+function aggregateEntryToChip(entry) {
+    if (entry.type === 'year') {
+        return { text: entry.key + '-01..' + entry.key + '-12', type: 'month', mode: 'include', displayText: entry.label };
+    }
+    if (entry.type === 'quarter') {
+        const parts = entry.key.split('-Q');
+        const startM = (parseInt(parts[1], 10) - 1) * 3 + 1;
+        return {
+            text: parts[0] + '-' + pad2(startM) + '..' + parts[0] + '-' + pad2(startM + 2),
+            type: 'month', mode: 'include', displayText: entry.label
+        };
+    }
+    return { text: entry.key, type: 'month', mode: 'include', displayText: monthKeyLabel(entry.key) };
+}
+
+// Restore a display label for a 'month'-type chip after a hash reload: plain
+// month, a full-year range, a quarter range, or a generic month range.
+function monthChipDisplayText(text) {
+    if (!text.includes('..')) return monthKeyLabel(text);
+    const [start, end] = text.split('..');
+    const [sy, sm] = start.split('-');
+    const [ey, em] = end.split('-');
+    if (sy === ey && sm === '01' && em === '12') return sy;               // Year
+    if (sy === ey) {
+        const smN = parseInt(sm, 10), emN = parseInt(em, 10);
+        if (emN - smN === 2 && (smN - 1) % 3 === 0) {                     // Quarter
+            return 'Q' + quarterOf(smN) + ' ' + sy;
+        }
+    }
+    return monthKeyLabel(start) + ' – ' + monthKeyLabel(end);            // Generic range
+}
+
+// Cross-year-aware label for a 'daterange' chip ('YYYY-MM-DD..YYYY-MM-DD').
+// Year shown on both ends when they differ, once (on end) when they match.
+function dateRangeDisplayText(text) {
+    const [a, b] = String(text).split('..');
+    // Hand-edited hashes can carry anything; fall back to the raw text rather
+    // than throwing on a missing/malformed half.
+    const iso = /^\d{4}-\d{1,2}-\d{1,2}$/;
+    if (!iso.test(a || '') || !iso.test(b || '')) return text;
+    const ap = a.split('-'), bp = b.split('-');
+    const startPart = MONTH_NAMES_SHORT[parseInt(ap[1], 10) - 1] + ' ' + parseInt(ap[2], 10) +
+        (ap[0] !== bp[0] ? ', ' + ap[0] : '');
+    return startPart + ' – ' + MONTH_NAMES_SHORT[parseInt(bp[1], 10) - 1] + ' ' + parseInt(bp[2], 10) + ', ' + bp[0];
+}
+
+function parseTypedDate(str) {
+    str = (str || '').trim();
+    if (!str) return null;
+    const m1 = str.match(/^(\d{4})-(\d{1,2})-(\d{1,2})$/);
+    if (m1) return { y: +m1[1], m: +m1[2], d: +m1[3] };
+    const m2 = str.match(/^(\d{1,2})\/(\d{1,2})\/(\d{4})$/);
+    if (m2) return { y: +m2[3], m: +m2[1], d: +m2[2] };
+    const d = new Date(str);
+    if (!isNaN(d.getTime())) return { y: d.getFullYear(), m: d.getMonth() + 1, d: d.getDate() };
+    return null;
+}
+function fmtDrillDate(dt) { return MONTH_NAMES_SHORT[dt.m - 1] + ' ' + dt.d + ', ' + dt.y; }
+function dateToKey(dt) { return dt.y + '-' + pad2(dt.m) + '-' + pad2(dt.d); }
+
 // ========== REUSABLE COMPONENTS ==========
 
 // Sortable merchant/group section component
@@ -126,6 +277,8 @@ const MerchantSection = defineComponent({
         formatDate: { type: Function, required: true },
         formatPct: { type: Function, default: null },
         addFilter: { type: Function, required: true },
+        isIncludeFilterActive: { type: Function, required: true },
+        toggleIncludeFilter: { type: Function, required: true },
         highlightDescription: { type: Function, default: (d) => d },
         tagColor: { type: Function, default: () => '#888' }
     },
@@ -140,11 +293,11 @@ const MerchantSection = defineComponent({
         }
     },
     template: `
-        <section :class="[sectionKey.replace(':', '-') + '-section', 'category-section']" :data-testid="'section-' + sectionKey.replace(':', '-')">
+        <section :class="[sectionKey.replace(':', '-') + '-section', 'category-section', { 'is-collapsed': collapsedSections.has(sectionKey) }]" :data-testid="'section-' + sectionKey.replace(':', '-')">
             <div class="section-header" @click="toggleSection(sectionKey)">
                 <h2>
                     <span class="toggle">{{ collapsedSections.has(sectionKey) ? '▶' : '▼' }}</span>
-                    <span v-if="headerColor" class="category-dot" :style="{ backgroundColor: headerColor }"></span>
+                    <span v-if="headerColor" class="category-dot" :style="{ backgroundColor: headerColor, '--dot-color': headerColor }"></span>
                     {{ title }}
                 </h2>
                 <span class="section-total">
@@ -174,14 +327,14 @@ const MerchantSection = defineComponent({
                                 <th @click.stop="toggleSort(sectionKey, 'subcategory')"
                                     :class="getSortClass('subcategory')">{{ subcategoryMode ? 'Merchants' : (categoryMode ? 'Subcategory' : 'Category') }}</th>
                                 <!-- Category mode: Count then Tags; Other modes: Tags then Count -->
-                                <th v-if="categoryMode" @click.stop="toggleSort(sectionKey, 'count')"
+                                <th v-if="categoryMode" class="count-col" @click.stop="toggleSort(sectionKey, 'count')"
                                     :class="getSortClass('count')">Count</th>
                                 <th>Tags</th>
-                                <th v-if="!categoryMode" @click.stop="toggleSort(sectionKey, 'count')"
+                                <th v-if="!categoryMode" class="count-col" @click.stop="toggleSort(sectionKey, 'count')"
                                     :class="getSortClass('count')">Count</th>
                                 <th class="money" @click.stop="toggleSort(sectionKey, 'total')"
                                     :class="getSortClass('total')">{{ creditMode ? 'Amount' : 'Total' }}</th>
-                                <th v-if="categoryMode" @click.stop="toggleSort(sectionKey, 'total')"
+                                <th v-if="categoryMode" class="pct" @click.stop="toggleSort(sectionKey, 'total')"
                                     :class="getSortClass('total')">%</th>
                             </tr>
                         </thead>
@@ -191,58 +344,63 @@ const MerchantSection = defineComponent({
                                     :class="{ expanded: isExpanded(item.id || idx) }"
                                     :data-testid="'merchant-row-' + (item.id || item.displayName || item.merchant || idx)"
                                     @click="toggleExpand(item.id || idx)">
-                                    <td class="merchant" :class="{ clickable: categoryMode }">
-                                        <span class="chevron">{{ isExpanded(item.id || idx) ? '▼' : '▶' }}</span>
-                                        <span class="merchant-name" @click.stop="categoryMode ? addFilter(item.id, subcategoryMode ? 'subcategory' : 'merchant', item.displayName) : null">
-                                            {{ item.displayName || item.merchant }}
-                                        </span>
-                                        <span v-if="item.matchInfo || item.viewInfo" class="match-info-trigger"
-                                                      @click.stop="togglePopup($event)">info
-                                            <span class="match-info-popup" ref="popup" @click.stop>
-                                                <button class="popup-close" @click="closePopup($event)">&times;</button>
-                                                <div class="popup-header">Why This Matched</div>
-                                                <template v-if="item.matchInfo">
-                                                    <div v-if="item.matchInfo.explanation" class="popup-explanation">{{ item.matchInfo.explanation }}</div>
-                                                    <div class="popup-section">
-                                                        <div class="popup-section-header">Merchant Pattern</div>
-                                                        <div class="popup-code">{{ item.matchInfo.pattern }}</div>
-                                                    </div>
-                                                    <div class="popup-section">
-                                                        <div class="popup-section-header">Assigned To</div>
-                                                        <div class="popup-row">
-                                                            <span class="popup-label">Merchant:</span>
-                                                            <span class="popup-value">{{ item.matchInfo.assignedMerchant }}</span>
+                                    <td class="merchant">
+                                        <div class="merchant-cell">
+                                            <span class="chevron">{{ isExpanded(item.id || idx) ? '▼' : '▶' }}</span>
+                                            <div class="merchant-body">
+                                                <span class="merchant-name">
+                                                    {{ item.displayName || item.merchant }}
+                                                </span>
+                                                <span class="merchant-actions" v-if="categoryMode">
+                                                    <span v-if="item.matchInfo || item.viewInfo" class="match-info-trigger"
+                                                          @click.stop="togglePopup($event)">info
+                                                <span class="match-info-popup" ref="popup" @click.stop>
+                                                    <button class="popup-close" @click="closePopup($event)">&times;</button>
+                                                    <div class="popup-header">Why This Matched</div>
+                                                    <template v-if="item.matchInfo">
+                                                        <div v-if="item.matchInfo.explanation" class="popup-explanation">{{ item.matchInfo.explanation }}</div>
+                                                        <div class="popup-section">
+                                                            <div class="popup-section-header">Merchant Pattern</div>
+                                                            <div class="popup-code">{{ item.matchInfo.pattern }}</div>
                                                         </div>
-                                                        <div class="popup-row">
-                                                            <span class="popup-label">Category:</span>
-                                                            <span class="popup-value">{{ item.matchInfo.assignedCategory }} / {{ item.matchInfo.assignedSubcategory }}</span>
+                                                        <div class="popup-section">
+                                                            <div class="popup-section-header">{{ item.matchInfo.ruleName ? 'Rule: [' + item.matchInfo.ruleName + ']' : 'Tag Rules Matched' }}</div>
+                                                            <div v-if="item.matchInfo.ruleName || (item.matchInfo.assignedCategory && item.matchInfo.assignedCategory !== 'Unknown')" class="popup-row">
+                                                                <span class="popup-label">Merchant:</span>
+                                                                <span class="popup-value">{{ item.matchInfo.assignedMerchant }}</span>
+                                                            </div>
+                                                            <div v-if="item.matchInfo.ruleName || (item.matchInfo.assignedCategory && item.matchInfo.assignedCategory !== 'Unknown')" class="popup-row">
+                                                                <span class="popup-label">Category:</span>
+                                                                <span class="popup-value">{{ item.matchInfo.assignedCategory }} / {{ item.matchInfo.assignedSubcategory }}</span>
+                                                            </div>
+                                                            <div v-for="(tag, tagIndex) in getTags(item)" :key="tag" class="popup-row popup-tag-row">
+                                                                <span class="popup-label">{{ tagIndex === 0 ? 'Tags:' : '' }}</span>
+                                                                <span class="popup-value">
+                                                                    <span class="tag-badge popup-tag-badge" :style="{ borderColor: tagColor(tag), color: tagColor(tag) }">{{ tag }}</span>
+                                                                    <span v-if="item.matchInfo.tagSources && item.matchInfo.tagSources[tag] && (!item.matchInfo.ruleName || item.matchInfo.tagSources[tag].rule !== item.matchInfo.ruleName)" class="popup-tag-source">
+                                                                        from [{{ item.matchInfo.tagSources[tag].rule }}]
+                                                                    </span>
+                                                                </span>
+                                                            </div>
                                                         </div>
-                                                        <div v-if="item.matchInfo.assignedTags && item.matchInfo.assignedTags.length" class="popup-row popup-tags-section">
-                                                            <span class="popup-label">Tags:</span>
-                                                            <span class="popup-value">
-                                                                <template v-if="item.matchInfo.tagSources && Object.keys(item.matchInfo.tagSources).length">
-                                                                    <div v-for="tag in item.matchInfo.assignedTags" :key="tag" class="popup-tag-item">
-                                                                        <span class="popup-tag-name">{{ tag }}</span>
-                                                                        <span v-if="item.matchInfo.tagSources[tag]" class="popup-tag-source">
-                                                                            from [{{ item.matchInfo.tagSources[tag].rule }}]
-                                                                        </span>
-                                                                    </div>
-                                                                </template>
-                                                                <template v-else>{{ item.matchInfo.assignedTags.join(', ') }}</template>
-                                                            </span>
+                                                    </template>
+                                                    <template v-if="item.viewInfo && item.viewInfo.filterExpr">
+                                                        <div class="popup-section popup-view-section">
+                                                            <div class="popup-section-header">View Filter ({{ item.viewInfo.viewName }})</div>
+                                                            <div v-if="item.viewInfo.explanation" class="popup-explanation" style="margin-top: 0.3em;">{{ item.viewInfo.explanation }}</div>
+                                                            <div class="popup-code">{{ item.viewInfo.filterExpr }}</div>
                                                         </div>
-                                                    </div>
-                                                </template>
-                                                <template v-if="item.viewInfo && item.viewInfo.filterExpr">
-                                                    <div class="popup-section">
-                                                        <div class="popup-section-header">View Filter ({{ item.viewInfo.viewName }})</div>
-                                                        <div v-if="item.viewInfo.explanation" class="popup-explanation" style="margin-top: 0.3em;">{{ item.viewInfo.explanation }}</div>
-                                                        <div class="popup-code">{{ item.viewInfo.filterExpr }}</div>
-                                                    </div>
-                                                </template>
-                                                <div v-if="item.matchInfo" class="popup-source">From: {{ item.matchInfo.source === 'user' ? 'merchants.rules' : item.matchInfo.source }}</div>
-                                            </span>
-                                        </span>
+                                                    </template>
+                                                    <div v-if="item.matchInfo" class="popup-source">From: {{ item.matchInfo.source === 'user' ? 'merchants.rules' : item.matchInfo.source }}</div>
+                                                </span>
+                                                    </span>
+                                                    <span v-if="item.matchInfo || item.viewInfo" class="merchant-action-sep">&middot;</span>
+                                                    <button type="button" class="merchant-filter-trigger" @click.stop="toggleMerchantFilter(item)">
+                                                        {{ isMerchantFiltered(item) ? 'clear' : 'filter' }}
+                                                    </button>
+                                                </span>
+                                            </div>
+                                        </div>
                                     </td>
                                     <td class="category" :class="{ clickable: categoryMode && !subcategoryMode }"
                                         @click.stop="categoryMode && !subcategoryMode && addFilter(item.subcategory, 'subcategory')">
@@ -261,13 +419,13 @@ const MerchantSection = defineComponent({
                                         <span v-else>{{ item.subcategory }}</span>
                                     </td>
                                     <!-- Category mode: Count then Tags; Other modes: Tags then Count -->
-                                    <td v-if="categoryMode" data-testid="merchant-count">{{ item.filteredCount || item.count }}</td>
+                                    <td v-if="categoryMode" class="count-col" data-testid="merchant-count">{{ item.filteredCount || item.count }}</td>
                                     <td class="tags-cell">
                                         <span v-for="tag in getTags(item)" :key="tag" class="tag-badge" data-testid="tag-badge"
                                               :style="{ borderColor: tagColor(tag), color: tagColor(tag) }"
                                               @click.stop="addFilter(tag, 'tag')">{{ tag }}</span>
                                     </td>
-                                    <td v-if="!categoryMode" data-testid="merchant-count">{{ item.filteredCount || item.count }}</td>
+                                    <td v-if="!categoryMode" class="count-col" data-testid="merchant-count">{{ item.filteredCount || item.count }}</td>
                                     <td class="money" :class="getAmountClass(item)" data-testid="merchant-total">
                                         {{ formatAmount(item) }}
                                     </td>
@@ -299,8 +457,11 @@ const MerchantSection = defineComponent({
                                                     </div>
                                                 </span>
                                             </span>
-                                            <span class="txn-date">{{ formatDate(txn.date) }}</span>
-                                            <span class="txn-desc"><span v-if="txn.source" class="txn-source" :class="txn.source.toLowerCase()">{{ txn.source }}</span> <span v-html="highlightDescription(txn.description)"></span></span>
+                                            <span class="txn-date">{{ formatDate(txn.date, txn.month) }}</span>
+                                            <span class="txn-account">
+                                                <span v-if="txn.source" class="txn-source" :class="txn.source.toLowerCase()">{{ txn.source }}</span>
+                                            </span>
+                                            <span class="txn-desc"><span v-html="highlightDescription(txn.description)"></span></span>
                                             <span class="txn-badges">
                                                 <span v-for="tag in [...(txn.tags || [])].sort()"
                                                       :key="tag"
@@ -316,6 +477,8 @@ const MerchantSection = defineComponent({
                                     </td>
                                 </tr>
                             </template>
+                        </tbody>
+                        <tfoot>
                             <tr class="total-row">
                                 <td :colspan="colSpan">{{ totalLabel }}</td>
                                 <td class="money" :class="{ 'credit-amount': creditMode }">
@@ -323,7 +486,7 @@ const MerchantSection = defineComponent({
                                 </td>
                                 <td v-if="categoryMode" class="pct">100%</td>
                             </tr>
-                        </tbody>
+                        </tfoot>
                     </table>
                 </div>
             </div>
@@ -380,6 +543,20 @@ const MerchantSection = defineComponent({
                 tags = item.tags || [];
             }
             return [...tags].sort((a, b) => a.localeCompare(b));
+        },
+        getFilterDescriptor(item) {
+            const type = this.subcategoryMode ? 'subcategory' : 'merchant';
+            const text = this.subcategoryMode ? (item.subcategory || item.displayName || item.id) : (item.displayName || item.id);
+            const displayText = item.displayName || item.merchant || text;
+            return { text, type, displayText };
+        },
+        isMerchantFiltered(item) {
+            const { text, type } = this.getFilterDescriptor(item);
+            return this.isIncludeFilterActive(text, type);
+        },
+        toggleMerchantFilter(item) {
+            const { text, type, displayText } = this.getFilterDescriptor(item);
+            this.toggleIncludeFilter(text, type, displayText);
         },
         getTransactions(item) {
             const txns = item.filteredTxns || item.transactions || [];
@@ -454,6 +631,170 @@ const MerchantSection = defineComponent({
     }
 });
 
+// Drill-down calendar widget for the custom Start/End date inputs.
+// Three views: 'days' (Month + Year drill buttons + day grid), 'months'
+// (Year drill + 3x4 month grid), 'years' (paginated 3x4 year grid).
+// Ported from createDrillCalendar() in the datefilter.html prototype.
+const DrillCalendar = defineComponent({
+    name: 'DrillCalendar',
+    props: {
+        modelValue: { type: Object, default: null }, // { y, m, d } | null
+        testidPrefix: { type: String, default: 'cal' },
+        alignRight: { type: Boolean, default: false },
+        placeholder: { type: String, default: '' }
+    },
+    emits: ['update:modelValue'],
+    data() {
+        const now = new Date();
+        return {
+            view: 'days',
+            viewYear: now.getFullYear(),
+            viewMonth: now.getMonth() + 1,
+            yearPageStart: 1,
+            calOpen: false,
+            textValue: this.modelValue ? fmtDrillDate(this.modelValue) : '',
+            invalid: false
+        };
+    },
+    computed: {
+        selected() { return this.modelValue; },
+        dowLabels() { return ['S', 'M', 'T', 'W', 'T', 'F', 'S']; },
+        monthNamesShort() { return MONTH_NAMES_SHORT; },
+        monthNamesLong() { return MONTH_NAMES_LONG; },
+        dayCells() {
+            const y = this.viewYear, m = this.viewMonth;
+            const blanks = new Date(y, m - 1, 1).getDay();
+            const total = new Date(y, m, 0).getDate();
+            const t = new Date();
+            const cells = [];
+            for (let i = 0; i < blanks; i++) cells.push({ empty: true, key: 'b' + i });
+            for (let d = 1; d <= total; d++) {
+                cells.push({
+                    empty: false, day: d, key: 'd' + d,
+                    selected: this.selected && this.selected.y === y && this.selected.m === m && this.selected.d === d,
+                    today: t.getFullYear() === y && (t.getMonth() + 1) === m && t.getDate() === d
+                });
+            }
+            return cells;
+        },
+        yearPageCells() {
+            const cells = [];
+            for (let y = this.yearPageStart; y <= this.yearPageStart + 11; y++) cells.push(y);
+            return cells;
+        },
+        yearPageLabel() { return this.yearPageStart + '–' + (this.yearPageStart + 11); }
+    },
+    watch: {
+        modelValue(v) {
+            this.textValue = v ? fmtDrillDate(v) : '';
+            this.invalid = false;
+        }
+    },
+    methods: {
+        alignPage(y) { return Math.floor((y - 1) / 12) * 12 + 1; },
+        openCal() {
+            const now = new Date();
+            const base = this.selected || { y: now.getFullYear(), m: now.getMonth() + 1, d: now.getDate() };
+            this.viewYear = base.y;
+            this.viewMonth = base.m;
+            this.yearPageStart = this.alignPage(this.viewYear);
+            this.view = 'days';
+            this.calOpen = true;
+        },
+        toggleCal() { if (this.calOpen) this.calOpen = false; else this.openCal(); },
+        onTextChange() {
+            const parsed = parseTypedDate(this.textValue);
+            if (parsed) {
+                this.textValue = fmtDrillDate(parsed);
+                this.invalid = false;
+                this.$emit('update:modelValue', parsed);
+            } else if (this.textValue.trim() === '') {
+                this.invalid = false;
+                this.$emit('update:modelValue', null);
+            } else {
+                this.invalid = true;
+            }
+        },
+        prevMonth() { this.viewMonth--; if (this.viewMonth < 1) { this.viewMonth = 12; this.viewYear--; } },
+        nextMonth() { this.viewMonth++; if (this.viewMonth > 12) { this.viewMonth = 1; this.viewYear++; } },
+        drillToMonths() { this.view = 'months'; },
+        drillToYears() { this.yearPageStart = this.alignPage(this.viewYear); this.view = 'years'; },
+        pickDay(d) {
+            const sel = { y: this.viewYear, m: this.viewMonth, d };
+            this.textValue = fmtDrillDate(sel);
+            this.invalid = false;
+            this.calOpen = false;
+            this.$emit('update:modelValue', sel);
+        },
+        pickMonth(i) { this.viewMonth = i + 1; this.view = 'days'; },
+        pickYear(y) { this.viewYear = y; this.view = 'months'; },
+        prevMonthsYear() { this.viewYear--; },
+        nextMonthsYear() { this.viewYear++; },
+        prevYearPage() { this.yearPageStart -= 12; },
+        nextYearPage() { this.yearPageStart += 12; },
+        onDocClick(e) {
+            if (this.calOpen && this.$el && !this.$el.contains(e.target)) this.calOpen = false;
+        }
+    },
+    mounted() { document.addEventListener('click', this.onDocClick); },
+    unmounted() { document.removeEventListener('click', this.onDocClick); },
+    template: `
+        <div class="drill-calendar" :class="{ 'align-right': alignRight }" @click.stop>
+            <div class="date-input">
+                <input type="text" :class="{ invalid }" v-model="textValue" @change="onTextChange"
+                       :data-testid="testidPrefix + '-text'" :placeholder="placeholder">
+                <button type="button" class="cal-btn" :data-testid="testidPrefix + '-cal-btn'" @click="toggleCal">📅</button>
+            </div>
+            <div class="cal-popover" v-if="calOpen" :data-testid="testidPrefix + '-cal'">
+                <template v-if="view === 'days'">
+                    <div class="cal-header">
+                        <button type="button" class="cal-nav" @click="prevMonth">‹</button>
+                        <div class="cal-title">
+                            <button type="button" class="cal-drill" @click="drillToMonths">{{ monthNamesLong[viewMonth - 1] }}</button>
+                            <button type="button" class="cal-drill" @click="drillToYears">{{ viewYear }}</button>
+                        </div>
+                        <button type="button" class="cal-nav" @click="nextMonth">›</button>
+                    </div>
+                    <div class="cal-dow"><span v-for="(d, i) in dowLabels" :key="i">{{ d }}</span></div>
+                    <div class="cal-days">
+                        <template v-for="cell in dayCells" :key="cell.key">
+                            <span v-if="cell.empty" class="cal-day empty"></span>
+                            <button v-else type="button" class="cal-day"
+                                    :class="{ selected: cell.selected, today: cell.today }"
+                                    :data-testid="testidPrefix + '-day-' + cell.day"
+                                    @click="pickDay(cell.day)">{{ cell.day }}</button>
+                        </template>
+                    </div>
+                </template>
+                <template v-else-if="view === 'months'">
+                    <div class="cal-header">
+                        <button type="button" class="cal-nav" @click="prevMonthsYear">‹</button>
+                        <div class="cal-title"><button type="button" class="cal-drill" @click="drillToYears">{{ viewYear }}</button></div>
+                        <button type="button" class="cal-nav" @click="nextMonthsYear">›</button>
+                    </div>
+                    <div class="cal-months">
+                        <button v-for="(name, i) in monthNamesShort" :key="i" type="button" class="cal-cell"
+                                :class="{ selected: selected && selected.y === viewYear && selected.m === i + 1 }"
+                                @click="pickMonth(i)">{{ name }}</button>
+                    </div>
+                </template>
+                <template v-else>
+                    <div class="cal-header">
+                        <button type="button" class="cal-nav" @click="prevYearPage">‹</button>
+                        <div class="cal-title">{{ yearPageLabel }}</div>
+                        <button type="button" class="cal-nav" @click="nextYearPage">›</button>
+                    </div>
+                    <div class="cal-years">
+                        <button v-for="y in yearPageCells" :key="y" type="button" class="cal-cell"
+                                :class="{ selected: selected && selected.y === y }"
+                                @click="pickYear(y)">{{ y }}</button>
+                    </div>
+                </template>
+            </div>
+        </div>
+    `
+});
+
 // Category colors for charts
 const CATEGORY_COLORS = [
     '#4facfe', '#00f2fe', '#4dffd2', '#ffa94d', '#f5af19',
@@ -461,12 +802,20 @@ const CATEGORY_COLORS = [
     '#10b981', '#f59e0b', '#ef4444', '#8b5cf6', '#06b6d4'
 ];
 
+// Category charts show the top N categories; the rest roll up into "Other"
+// so totals still reflect all spending
+const TOP_CATEGORY_COUNT = 10;
+const OTHER_CATEGORY_LABEL = 'Other';
+const OTHER_CATEGORY_COLOR = '#6b7280';
+
 // Tag colors (distinct from category colors, warmer/earthier tones)
 const TAG_COLORS = [
     '#e879f9', '#c084fc', '#a78bfa', '#818cf8', '#6366f1',
     '#f472b6', '#fb7185', '#f87171', '#fb923c', '#fbbf24',
     '#a3e635', '#4ade80', '#34d399', '#2dd4bf', '#22d3ee'
 ];
+
+const UI_STATE_KEY = 'spending-report-ui-state-v1';
 
 createApp({
     setup() {
@@ -481,11 +830,18 @@ createApp({
         const isScrolled = ref(false);
         const isDarkTheme = ref(true);
         const chartsCollapsed = ref(false);
-        const helpCollapsed = ref(true);
+        const detailsCollapsed = ref(false);
         const currentView = ref('category'); // 'category' or 'section'
         const groupByMode = ref('merchant'); // 'merchant' or 'subcategory'
         const sortConfig = reactive({}); // { 'cat:Food': { column: 'total', dir: 'desc' } }
         const includeNegativeTotals = ref(false); // show categories with negative filteredTotal
+        const txColumnProfiles = reactive({ merchant: null, subcategory: null, section: null });
+        let isHydratingUiState = true;
+        let txMeasureHost = null;
+        let txMeasureDateEl = null;
+        let txMeasureAmountEl = null;
+        let txMeasureAccountEl = null;
+        let txResizeDebounceHandle = null;
 
         // Chart refs
         const monthlyChart = ref(null);
@@ -496,6 +852,9 @@ createApp({
         let monthlyChartInstance = null;
         let pieChartInstance = null;
         let categoryMonthChartInstance = null;
+        // Months actually plotted on the monthly trend chart; bar clicks index into
+        // this, not availableMonths, since empty months and date filters drop months
+        let monthlyChartMonths = [];
 
         // ========== COMPUTED ==========
 
@@ -508,6 +867,34 @@ createApp({
             const data = spendingData.value;
             const sources = data.sources || [];
             return sources.length > 0 ? `Data from ${sources.join(', ')}` : '';
+        });
+
+        const allPersistableSectionKeys = computed(() => {
+            const keys = new Set();
+            Object.keys(spendingData.value.categoryView || {}).forEach(name => keys.add('cat:' + name));
+            Object.keys(spendingData.value.sections || {}).forEach(id => keys.add('sec:' + id));
+            return keys;
+        });
+
+        const allPersistableItemIds = computed(() => {
+            const ids = new Set();
+
+            for (const category of Object.values(spendingData.value.categoryView || {})) {
+                for (const [subName, subcat] of Object.entries(category.subcategories || {})) {
+                    ids.add(subName);
+                    for (const merchantId of Object.keys(subcat.merchants || {})) {
+                        ids.add(String(merchantId));
+                    }
+                }
+            }
+
+            for (const section of Object.values(spendingData.value.sections || {})) {
+                for (const merchantId of Object.keys(section.merchants || {})) {
+                    ids.add(String(merchantId));
+                }
+            }
+
+            return ids;
         });
 
         // Core filtering - returns sections with filtered merchants and transactions
@@ -773,6 +1160,30 @@ createApp({
 
         // Credit merchants (negative totals, shown separately)
         // Excludes income and transfer tagged merchants
+        //
+        // Not rendered right now: the "Credits Applied" section that consumed this was
+        // dropped from spending_report.html in ad9477e, though docs/reference.html still
+        // documents it (refund tag -> shown in "Credits Applied", nets against spending).
+        //
+        // KNOWN BUG, fix before re-enabling: isExcludedFromSpending(merchant.tags) below is
+        // a whole-merchant decision made from merchant.tags, which analyzer.py builds as the
+        // UNION of every tag across that merchant's transactions. A single transfer-tagged
+        // txn therefore discards all of the merchant's refunds - on a real dataset Amazon's
+        // union is [monthly-bill, refund, transfer], so every Amazon credit vanishes.
+        // filteredViewTotals and chartAggregations classify per transaction (txn.tags); this
+        // must too. Two ways, and they mean different things:
+        //   1. Net-negative merchants - net each merchant's per-txn spending against its
+        //      per-txn credits, list it when net < 0. Preserves what the section means today
+        //      and stays a short list, but "Total Credits" still won't equal the Credits KPI:
+        //      a refund absorbed inside a net-positive merchant stays invisible. Only works
+        //      when refunds arrive under their own merchant name (e.g. "Amazon Refund").
+        //   2. Any merchant with credits - list it when sum(txn credits) > 0 and show that
+        //      sum. Gives the identity sum(creditAmount) === filteredViewTotals.credits under
+        //      every filter, so the section reconciles with the Credits KPI and Python's
+        //      credits_total. Costs a longer list: a merchant can appear both as spending and
+        //      as a credit (Amazon: $6,910 spent, refunds back).
+        //
+        // grandTotal below has the same merchant-union flaw and is likewise unrendered.
         const unsortedCreditMerchants = computed(() => {
             const credits = [];
             for (const [catName, category] of Object.entries(filteredCategoryView.value)) {
@@ -869,6 +1280,13 @@ createApp({
             return result;
         });
 
+        // Count of hidden negative-total items (categories or sections, depending on view)
+        // Used for the badge on the Include/Exclude Negatives toggle button
+        const negativeTotalsCount = computed(() => {
+            const source = currentView.value === 'section' ? filteredSectionView.value : filteredCategoryView.value;
+            return Object.values(source).filter(item => item.filteredTotal < 0).length;
+        });
+
         // Totals per section
         const sectionTotals = computed(() => {
             const totals = {};
@@ -902,11 +1320,6 @@ createApp({
             return creditMerchants.value.reduce((sum, m) => sum + m.creditAmount, 0);
         });
 
-        // Gross spending (before credits)
-        const grossSpending = computed(() => {
-            return grandTotal.value + creditsTotal.value;
-        });
-
         // Filtered view totals - sum of ALL matching transactions
         // Simple: whatever matches the filters gets counted and categorized
         const filteredViewTotals = computed(() => {
@@ -925,12 +1338,14 @@ createApp({
             for (const cat of Object.values(filteredCategoryView.value)) {
                 for (const subcat of Object.values(cat.filteredSubcategories || cat.subcategories || {})) {
                     for (const merchant of Object.values(subcat.filteredMerchants || subcat.merchants || {})) {
-                        const tags = merchant.tags || [];
                         const txns = merchant.filteredTxns || merchant.transactions || [];
 
                         for (const txn of txns) {
-                            // Use centralized categorizeAmount() for consistent classification
-                            const c = categorizeAmount(txn.amount || 0, tags);
+                            // Classify with the transaction's OWN tags. merchant.tags is a
+                            // union of every tag across the merchant's transactions
+                            // (analyzer.py builds it that way), so using it here would let a
+                            // single income/transfer-tagged txn re-bucket all the others.
+                            const c = categorizeAmount(txn.amount || 0, txn.tags || []);
                             totals.income += c.income;
                             totals.investment += c.investment;
                             totals.transferIn += c.transferIn;
@@ -969,6 +1384,11 @@ createApp({
                 hasIncome: totals.income > 0  // For display formatting
             };
         });
+
+        // Gross spending (before credits). categorizeAmount() already separates positive
+        // spend from refunds per transaction, so this is the sum of spending-tagged
+        // amounts - no need to net merchants out and add their credits back in.
+        const grossSpending = computed(() => filteredViewTotals.value.spending);
 
         // Cash flow totals from data (excludes transfers and investments)
         const incomeTotal = computed(() => spendingData.value.incomeTotal || 0);
@@ -1068,27 +1488,38 @@ createApp({
         // Number of months in filter (for monthly averages)
         const numFilteredMonths = computed(() => {
             const monthFilters = activeFilters.value.filter(f =>
-                f.type === 'month' && f.mode === 'include'
+                filterCategory(f.type) === 'date' && f.mode === 'include'
             );
             if (monthFilters.length === 0) return spendingData.value.numMonths || 12;
 
             const months = new Set();
             monthFilters.forEach(f => {
-                if (f.text.includes('..')) {
-                    expandMonthRange(f.text).forEach(m => months.add(m));
-                } else {
-                    months.add(f.text);
-                }
+                expandFilterMonths(f).forEach(m => months.add(m));
             });
             return months.size || 1;
         });
 
+        // Expand a date filter chip (month, month-range, or daterange) into the
+        // set of whole-month keys it touches. daterange chips are approximated
+        // to whole months here (fine for averaging/chart bucketing; displayed
+        // totals stay day-accurate via passesFilters).
+        function expandFilterMonths(f) {
+            if (f.type === 'daterange') {
+                const [s, e] = f.text.split('..');
+                if (!s || !e) return [];   // Malformed (hand-edited hash): touches no months.
+                return expandMonthRange(s.slice(0, 7) + '..' + e.slice(0, 7));
+            }
+            if (f.text.includes('..')) return expandMonthRange(f.text);
+            return [f.text];
+        }
+
         // Chart data aggregations - always uses categoryView for consistent data
-        // Includes spending, income, and investment; excludes transfers (money moving between accounts)
+        // Includes spending, income, credits, and investment; excludes transfers (money moving between accounts)
         const chartAggregations = computed(() => {
             const spendingByMonth = {};
             const incomeByMonth = {};
             const investmentByMonth = {};
+            const creditsByMonth = {};
             const byCategory = {};  // Spending only (income doesn't have meaningful categories)
             const byCategoryByMonth = {};
 
@@ -1097,11 +1528,10 @@ createApp({
             for (const [catName, category] of Object.entries(categoryView)) {
                 for (const subcat of Object.values(category.filteredSubcategories || {})) {
                     for (const merchant of Object.values(subcat.filteredMerchants || {})) {
-                        const tags = merchant.tags || [];
-
                         for (const txn of merchant.filteredTxns || []) {
-                            // Use centralized categorization
-                            const c = categorizeAmount(txn.amount, tags);
+                            // Classify with the transaction's OWN tags, not merchant.tags
+                            // (a union across the merchant's txns) - see filteredViewTotals
+                            const c = categorizeAmount(txn.amount, txn.tags || []);
 
                             // Track spending by month and category
                             if (c.spending > 0) {
@@ -1122,13 +1552,18 @@ createApp({
                                 investmentByMonth[txn.month] = (investmentByMonth[txn.month] || 0) + c.investment;
                             }
 
+                            // Track credits by month (refunds are part of cash flow)
+                            if (c.credits > 0) {
+                                creditsByMonth[txn.month] = (creditsByMonth[txn.month] || 0) + c.credits;
+                            }
+
                             // Transfers excluded - they're just money moving between accounts
                         }
                     }
                 }
             }
 
-            return { spendingByMonth, incomeByMonth, investmentByMonth, byCategory, byCategoryByMonth };
+            return { spendingByMonth, incomeByMonth, investmentByMonth, creditsByMonth, byCategory, byCategoryByMonth };
         });
 
         // Map category names to colors (matches pie chart order)
@@ -1188,18 +1623,14 @@ createApp({
         // Filtered months for charts (respects month filters)
         const filteredMonthsForCharts = computed(() => {
             const monthFilters = activeFilters.value.filter(f =>
-                f.type === 'month' && f.mode === 'include'
+                filterCategory(f.type) === 'date' && f.mode === 'include'
             );
             if (monthFilters.length === 0) return availableMonths.value;
 
             // Build set of included months
             const includedMonths = new Set();
             monthFilters.forEach(f => {
-                if (f.text.includes('..')) {
-                    expandMonthRange(f.text).forEach(m => includedMonths.add(m));
-                } else {
-                    includedMonths.add(f.text);
-                }
+                expandFilterMonths(f).forEach(m => includedMonths.add(m));
             });
 
             return availableMonths.value.filter(m => includedMonths.has(m.key));
@@ -1294,7 +1725,8 @@ createApp({
         });
 
         function getDisplayText(type, filterText) {
-            if (type === 'month') return formatMonthLabel(filterText);
+            if (type === 'month') return monthChipDisplayText(filterText);
+            if (type === 'daterange') return dateRangeDisplayText(filterText);
             return displayTextLookup.value[`${type}:${filterText}`] || filterText;
         }
 
@@ -1327,29 +1759,19 @@ createApp({
             return matches;
         });
 
-        // Available months for date picker
+        // Available months for date picker.
+        // Sourced exclusively from categoryView, which is built from ALL
+        // merchants (report.py build_category_view) and is a strict superset of
+        // sections: a merchant matching zero views is absent from `sections` by
+        // design, so sourcing from `sections` silently drops its months.
         const availableMonths = computed(() => {
             const months = new Set();
-            const sections = spendingData.value.sections || {};
-
-            // Use sections if available, otherwise fall back to categoryView
-            if (Object.keys(sections).length > 0) {
-                for (const section of Object.values(sections)) {
-                    for (const merchant of Object.values(section.merchants || {})) {
+            const categoryView = spendingData.value.categoryView || {};
+            for (const category of Object.values(categoryView)) {
+                for (const subcat of Object.values(category.subcategories || {})) {
+                    for (const merchant of Object.values(subcat.merchants || {})) {
                         for (const txn of merchant.transactions || []) {
                             months.add(txn.month);
-                        }
-                    }
-                }
-            } else {
-                // Fall back to categoryView when no views configured
-                const categoryView = spendingData.value.categoryView || {};
-                for (const category of Object.values(categoryView)) {
-                    for (const subcat of Object.values(category.subcategories || {})) {
-                        for (const merchant of Object.values(subcat.merchants || {})) {
-                            for (const txn of merchant.transactions || []) {
-                                months.add(txn.month);
-                            }
                         }
                     }
                 }
@@ -1371,20 +1793,28 @@ createApp({
                 if (matchesFilter(txn, merchant, f)) return false;
             }
 
-            // Group includes by type
+            // Group includes by filter category (month + daterange collapse to
+            // one 'date' category so they OR together rather than AND).
             const byType = {};
             includes.forEach(f => {
-                if (!byType[f.type]) byType[f.type] = [];
-                byType[f.type].push(f);
+                const cat = filterCategory(f.type);
+                if (!byType[cat]) byType[cat] = [];
+                byType[cat].push(f);
             });
 
-            // AND across types, OR within type
-            for (const [type, filters] of Object.entries(byType)) {
+            // AND across categories, OR within a category
+            for (const [cat, filters] of Object.entries(byType)) {
                 const anyMatch = filters.some(f => matchesFilter(txn, merchant, f));
                 if (!anyMatch) return false;
             }
 
             return true;
+        }
+
+        // Reconstruct a day-precision YYYY-MM-DD for a transaction, mirroring
+        // analyzer.py's CSV export: month (YYYY-MM) + day from date (MM/DD).
+        function txnFullDate(txn) {
+            return `${txn.month}-${(txn.date || '00/00').slice(3, 5)}`;
         }
 
         function matchesFilter(txn, merchant, filter) {
@@ -1399,6 +1829,11 @@ createApp({
                     return merchant.subcategory.toLowerCase() === text;
                 case 'month':
                     return monthMatches(txn.month, filter.text);
+                case 'daterange': {
+                    const [start, end] = filter.text.split('..');
+                    const full = txnFullDate(txn);
+                    return full >= start && full <= end;
+                }
                 case 'tag':
                     return (txn.tags || []).some(t => t.toLowerCase() === text);
                 case 'text':
@@ -1439,7 +1874,28 @@ createApp({
         }
 
         function removeFilter(index) {
+            const removed = activeFilters.value[index];
             activeFilters.value.splice(index, 1);
+            // Removing a custom-range chip must also reset the Start/End widget
+            // so reopening the popover doesn't silently re-add it on Apply.
+            if (removed && removed.type === 'daterange') clearCustomRange();
+        }
+
+        function toggleIncludeFilter(text, type, displayText = null) {
+            const index = activeFilters.value.findIndex(f =>
+                f.mode === 'include' && f.text === text && f.type === type
+            );
+            if (index >= 0) {
+                removeFilter(index);
+            } else {
+                addFilter(text, type, displayText);
+            }
+        }
+
+        function isIncludeFilterActive(text, type) {
+            return activeFilters.value.some(f =>
+                f.mode === 'include' && f.text === text && f.type === type
+            );
         }
 
         function toggleFilterMode(index) {
@@ -1449,10 +1905,143 @@ createApp({
 
         function clearFilters() {
             activeFilters.value = [];
+            pendingMonths.clear();
+            clearCustomRange();
         }
 
         function addMonthFilter(month) {
             if (month) addFilter(month, 'month', formatMonthLabel(month));
+        }
+
+        // ========== DATE FILTER POPOVER (Month / Quarter / Year / Custom) ==========
+        const datePopoverOpen = ref(false);
+        const pendingMonths = reactive(new Set());   // flat set of 'YYYY-MM' keys
+        const activeYearTab = ref(null);
+        const customStart = ref(null);               // { y, m, d } | null
+        const customEnd = ref(null);
+
+        // Distinct years present in the data, ascending.
+        const availableYears = computed(() => {
+            const years = new Set();
+            availableMonths.value.forEach(m => years.add(parseInt(m.key.slice(0, 4), 10)));
+            return Array.from(years).sort((a, b) => a - b);
+        });
+        // Year tabs: up to 3 most recent data years, oldest -> newest.
+        const yearTabs = computed(() => availableYears.value.slice(-3));
+
+        // Real-today info driving the This/Last preset rows.
+        const todayInfo = computed(() => {
+            const now = new Date();
+            const y = now.getFullYear();
+            const mo = now.getMonth() + 1;
+            return { y, mo, q: quarterOf(mo), monthKey: y + '-' + pad2(mo) };
+        });
+        const thisLastPresets = computed(() => {
+            const t = todayInfo.value;
+            let lm = t.mo - 1, lmy = t.y;
+            if (lm < 1) { lm = 12; lmy -= 1; }
+            let lq = t.q - 1, lqy = t.y;
+            if (lq < 1) { lq = 4; lqy -= 1; }
+            const ly = t.y - 1;
+            return {
+                thisRow: [
+                    { label: 'This Month', type: 'month', key: t.monthKey },
+                    { label: 'This Quarter', type: 'quarter', key: t.y + '-Q' + t.q },
+                    { label: 'This Year', type: 'year', key: String(t.y) }
+                ],
+                lastRow: [
+                    { label: 'Last Month', type: 'month', key: lmy + '-' + pad2(lm) },
+                    { label: 'Last Quarter', type: 'quarter', key: lqy + '-Q' + lq },
+                    { label: 'Last Year', type: 'year', key: String(ly) }
+                ]
+            };
+        });
+
+        // Months (with data) for the active year tab.
+        const activeYearMonths = computed(() =>
+            availableMonths.value.filter(m => m.key.slice(0, 4) === String(activeYearTab.value))
+        );
+
+        // A preset is "active" purely by coverage: every constituent month is
+        // currently pending. No separate quarter/year pending state.
+        function isDateItemActive(item) {
+            const months = monthsForItem(item);
+            return months.length > 0 && months.every(k => pendingMonths.has(k));
+        }
+        function toggleDateItem(item) {
+            const months = monthsForItem(item);
+            const active = isDateItemActive(item);
+            months.forEach(k => { if (active) pendingMonths.delete(k); else pendingMonths.add(k); });
+        }
+        function yearTabHasPending(year) {
+            for (const k of pendingMonths) if (k.slice(0, 4) === String(year)) return true;
+            return false;
+        }
+
+        function openDatePopover() {
+            // Expand currently-applied date chips (possibly aggregated into
+            // quarter/year ranges) back into flat pending months for editing.
+            pendingMonths.clear();
+            let rangeChip = null;
+            for (const f of activeFilters.value) {
+                if (f.type === 'month') {
+                    if (f.text.includes('..')) expandMonthRange(f.text).forEach(k => pendingMonths.add(k));
+                    else pendingMonths.add(f.text);
+                }
+                // daterange chips stay independent (never expanded to months),
+                // but the first one rehydrates the Start/End widget so an
+                // unedited Apply doesn't drop the applied range.
+                else if (f.type === 'daterange' && !rangeChip) rangeChip = f;
+            }
+            if (rangeChip) {
+                const [rawStart, rawEnd] = String(rangeChip.text).split('..');
+                const start = parseTypedDate(rawStart), end = parseTypedDate(rawEnd);
+                // Both halves must parse; a hand-edited hash must not wedge the widget.
+                if (start && end) { customStart.value = start; customEnd.value = end; }
+            }
+            const tabs = yearTabs.value;
+            const ty = todayInfo.value.y;
+            activeYearTab.value = tabs.includes(ty) ? ty : (tabs.length ? tabs[tabs.length - 1] : ty);
+            datePopoverOpen.value = true;
+        }
+        function toggleDatePopover() {
+            if (datePopoverOpen.value) datePopoverOpen.value = false;
+            else openDatePopover();
+        }
+        function closeDatePopover() { datePopoverOpen.value = false; }
+        function clearPendingMonths() { pendingMonths.clear(); }
+
+        function getCustomRangeChip() {
+            if (!customStart.value || !customEnd.value) return null;
+            let a = customStart.value, b = customEnd.value;
+            if (dateToKey(a) > dateToKey(b)) { const t = a; a = b; b = t; }
+            const text = dateToKey(a) + '..' + dateToKey(b);
+            return { text, type: 'daterange', mode: 'include', displayText: dateRangeDisplayText(text) };
+        }
+        function clearCustomRange() {
+            customStart.value = null;
+            customEnd.value = null;
+        }
+
+        // Apply: re-aggregate pending months into the fewest chips, then append
+        // the (independent) custom range. Existing date chips are replaced.
+        function applyDateFilters() {
+            activeFilters.value = activeFilters.value.filter(f => filterCategory(f.type) !== 'date');
+            aggregateMonthKeys([...pendingMonths]).forEach(entry =>
+                activeFilters.value.push(aggregateEntryToChip(entry))
+            );
+            const custom = getCustomRangeChip();
+            if (custom) activeFilters.value.push(custom);
+            datePopoverOpen.value = false;
+        }
+
+        // Footer "Clear all filters": destructive — wipes every filter, the
+        // pending set, and the custom-range widget, then closes.
+        function clearAllDateFilters() {
+            activeFilters.value = [];
+            pendingMonths.clear();
+            clearCustomRange();
+            datePopoverOpen.value = false;
         }
 
         function toggleExpand(merchantId) {
@@ -1470,6 +2059,51 @@ createApp({
                 collapsedSections.add(sectionId);
             }
         }
+
+        // Section keys currently visible in the active view (for collapse-all / expand-all)
+        const allSectionKeys = computed(() => {
+            if (currentView.value === 'section' && hasSections.value) {
+                return Object.keys(positiveSectionView.value).map(id => 'sec:' + id);
+            }
+            const view = groupByMode.value === 'subcategory' ? subcategoryGroupedView.value : positiveCategoryView.value;
+            return Object.keys(view).map(name => 'cat:' + name);
+        });
+        const allCollapsed = computed(() =>
+            allSectionKeys.value.length > 0 && allSectionKeys.value.every(k => collapsedSections.has(k))
+        );
+        // Collapse all: fold every category AND its open transaction lists ("the details")
+        function collapseAll() {
+            allSectionKeys.value.forEach(k => collapsedSections.add(k));
+            expandedMerchants.clear();
+        }
+        // Expand all: reopen top-level categories only (leave transaction lists folded)
+        function expandAll() {
+            collapsedSections.clear();
+        }
+        function toggleAllSections() {
+            if (allCollapsed.value) { expandAll(); } else { collapseAll(); }
+        }
+
+        // View-aware summary shown in the Transaction Details header
+        const pluralize = (n, one, many) => `${n} ${n === 1 ? one : many}`;
+        const detailsSummary = computed(() => {
+            if (currentView.value === 'section' && hasSections.value) {
+                const views = positiveSectionView.value;
+                let merchants = 0;
+                Object.values(views).forEach(s => { merchants += Object.keys(s.filteredMerchants || {}).length; });
+                return `${pluralize(Object.keys(views).length, 'view', 'views')}, ${pluralize(merchants, 'merchant', 'merchants')}`;
+            }
+            if (groupByMode.value === 'subcategory') {
+                const cats = subcategoryGroupedView.value;
+                let subs = 0;
+                Object.values(cats).forEach(c => { subs += (c.sortedSubcategories || []).length; });
+                return `${pluralize(Object.keys(cats).length, 'category', 'categories')}, ${pluralize(subs, 'subcategory', 'subcategories')}`;
+            }
+            const cats = positiveCategoryView.value;
+            let merchants = 0;
+            Object.values(cats).forEach(c => { merchants += (c.sortedMerchants || []).length; });
+            return `${pluralize(Object.keys(cats).length, 'category', 'categories')}, ${pluralize(merchants, 'merchant', 'merchants')}`;
+        });
 
         // Sort merchants by configurable column and direction (for object-based sections)
         function sortMerchantEntries(merchants, column, dir) {
@@ -1545,17 +2179,145 @@ createApp({
             return currencyFormat.replace('{amount}', amount.toFixed(0));
         }
 
-        function formatDate(dateStr) {
+        function formatDate(dateStr, monthStr) {
             if (!dateStr) return '';
+            const yearSuffix = monthStr ? `, ${monthStr.slice(0, 4)}` : '';
             // Handle MM/DD format from Python
             if (dateStr.match(/^\d{1,2}\/\d{1,2}$/)) {
                 const [month, day] = dateStr.split('/');
                 const months = ['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec'];
-                return `${months[parseInt(month)-1]} ${parseInt(day)}`;
+                return `${months[parseInt(month)-1]} ${parseInt(day)}${yearSuffix}`;
             }
             // Handle YYYY-MM-DD format
             const d = new Date(dateStr + 'T12:00:00');
-            return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+            return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
+        }
+
+        function getTxnModeKey() {
+            if (currentView.value === 'section' && hasSections.value) return 'section';
+            return groupByMode.value === 'subcategory' ? 'subcategory' : 'merchant';
+        }
+
+        function getTxnItemsForMode(mode) {
+            const items = [];
+            if (mode === 'section') {
+                const sections = spendingData.value.sections || {};
+                for (const section of Object.values(sections)) {
+                    items.push(...Object.values(section.merchants || {}));
+                }
+                return items;
+            }
+            const categoryView = spendingData.value.categoryView || {};
+            for (const category of Object.values(categoryView)) {
+                for (const subcat of Object.values(category.subcategories || {})) {
+                    items.push(...Object.values(subcat.merchants || {}));
+                }
+            }
+            return items;
+        }
+
+        function ensureTxnMeasureElements() {
+            if (txMeasureHost) return;
+            txMeasureHost = document.createElement('div');
+            txMeasureHost.style.position = 'fixed';
+            txMeasureHost.style.left = '-10000px';
+            txMeasureHost.style.top = '-10000px';
+            txMeasureHost.style.visibility = 'hidden';
+            txMeasureHost.style.pointerEvents = 'none';
+            txMeasureHost.style.whiteSpace = 'nowrap';
+            txMeasureHost.style.fontSize = '0.85rem';
+
+            txMeasureDateEl = document.createElement('span');
+            txMeasureDateEl.className = 'txn-date';
+            txMeasureAmountEl = document.createElement('span');
+            txMeasureAmountEl.className = 'txn-amount';
+            txMeasureAccountEl = document.createElement('span');
+            txMeasureAccountEl.className = 'txn-source';
+
+            txMeasureHost.appendChild(txMeasureDateEl);
+            txMeasureHost.appendChild(txMeasureAmountEl);
+            txMeasureHost.appendChild(txMeasureAccountEl);
+            document.body.appendChild(txMeasureHost);
+        }
+
+        function measureTxnDatePx(label) {
+            txMeasureDateEl.textContent = label || '';
+            return Math.ceil(txMeasureDateEl.getBoundingClientRect().width);
+        }
+
+        function measureTxnAmountPx(label) {
+            txMeasureAmountEl.textContent = label || '';
+            return Math.ceil(txMeasureAmountEl.getBoundingClientRect().width);
+        }
+
+        function measureTxnAccountPx(source) {
+            if (!source) return 0;
+            txMeasureAccountEl.className = 'txn-source ' + source.toLowerCase();
+            txMeasureAccountEl.textContent = source;
+            return Math.ceil(txMeasureAccountEl.getBoundingClientRect().width);
+        }
+
+        function formatTxnAmountLabel(txn) {
+            const tags = txn.tags || [];
+            if (isIncome(tags)) {
+                return '+' + formatCurrency(Math.abs(txn.amount));
+            }
+            return formatCurrency(txn.amount);
+        }
+
+        function clampPx(value, min, max) {
+            return Math.max(min, Math.min(max, value));
+        }
+
+        function measureTxnColumnsForMode(mode) {
+            ensureTxnMeasureElements();
+            const items = getTxnItemsForMode(mode);
+            let maxDate = 0;
+            let maxAccount = 0;
+            let maxAmount = 0;
+
+            for (const item of items) {
+                const txns = item.filteredTxns || item.transactions || [];
+
+                for (const txn of txns) {
+                    if (txn.date) {
+                        const dateLabel = formatDate(txn.date, txn.month);
+                        maxDate = Math.max(maxDate, measureTxnDatePx(dateLabel));
+                    }
+                    maxAccount = Math.max(maxAccount, measureTxnAccountPx(txn.source));
+                    maxAmount = Math.max(maxAmount, measureTxnAmountPx(formatTxnAmountLabel(txn)));
+                }
+            }
+
+            // Add small padding guardrails and clamp to desktop-appropriate bounds.
+            return {
+                date: clampPx(maxDate + 1, 70, 112),
+                account: clampPx(maxAccount + 10, 110, 260),
+                amount: clampPx(maxAmount + 4, 56, 160)
+            };
+        }
+
+        function applyTxnColumnProfile(mode = getTxnModeKey()) {
+            const profile = txColumnProfiles[mode];
+            if (!profile) return;
+            const rootStyle = document.documentElement.style;
+            rootStyle.setProperty('--txn-date-col', profile.date + 'px');
+            rootStyle.setProperty('--txn-account-col', profile.account + 'px');
+            rootStyle.setProperty('--txn-amount-col', profile.amount + 'px');
+        }
+
+        function recomputeTxnColumnProfiles() {
+            txColumnProfiles.merchant = measureTxnColumnsForMode('merchant');
+            txColumnProfiles.subcategory = measureTxnColumnsForMode('subcategory');
+            txColumnProfiles.section = hasSections.value ? measureTxnColumnsForMode('section') : txColumnProfiles.merchant;
+            applyTxnColumnProfile();
+        }
+
+        function recomputeTxnColumnsDebounced() {
+            if (txResizeDebounceHandle) clearTimeout(txResizeDebounceHandle);
+            txResizeDebounceHandle = setTimeout(() => {
+                recomputeTxnColumnProfiles();
+            }, 200);
         }
 
         function formatMonthLabel(key) {
@@ -1571,7 +2333,7 @@ createApp({
         }
 
         function filterTypeChar(type) {
-            return { category: 'c', subcategory: 'sc', merchant: 'm', month: 'd', tag: 't', text: 's' }[type] || '?';
+            return { category: 'c', subcategory: 'sc', merchant: 'm', month: 'd', daterange: 'dr', tag: 't', text: 's' }[type] || '?';
         }
 
         // Highlight search terms in transaction descriptions
@@ -1659,6 +2421,133 @@ createApp({
             }
         }
 
+        function toSortedArray(values) {
+            return [...values].map(v => String(v)).sort((a, b) => a.localeCompare(b));
+        }
+
+        function parseDetailsViewMode(currentViewMode, groupMode) {
+            if (currentViewMode === 'section') return 'section';
+            return groupMode === 'subcategory' ? 'subcategory' : 'merchant';
+        }
+
+        function applyDetailsViewMode(mode) {
+            if (mode === 'section' && hasSections.value) {
+                currentView.value = 'section';
+                return;
+            }
+            currentView.value = 'category';
+            groupByMode.value = mode === 'subcategory' ? 'subcategory' : 'merchant';
+        }
+
+        function saveUiState() {
+            if (isHydratingUiState) return;
+            try {
+                const state = {
+                    version: 1,
+                    detailsViewMode: parseDetailsViewMode(currentView.value, groupByMode.value),
+                    includeNegativeTotals: !!includeNegativeTotals.value,
+                    chartsCollapsed: !!chartsCollapsed.value,
+                    detailsCollapsed: !!detailsCollapsed.value,
+                    knownSectionKeys: toSortedArray(allPersistableSectionKeys.value),
+                    collapsedSectionKeys: toSortedArray(collapsedSections),
+                    knownItemIds: toSortedArray(allPersistableItemIds.value),
+                    expandedItemIds: toSortedArray(expandedMerchants),
+                    sortConfig: Object.fromEntries(
+                        Object.entries(sortConfig).map(([key, cfg]) => [key, {
+                            column: cfg?.column || 'total',
+                            dir: cfg?.dir === 'asc' ? 'asc' : 'desc'
+                        }])
+                    )
+                };
+                localStorage.setItem(UI_STATE_KEY, JSON.stringify(state));
+            } catch {
+                // Ignore localStorage failures (private mode/quota/security settings).
+            }
+        }
+
+        function normalizeUiStateForCurrentData() {
+            const validSectionKeys = allPersistableSectionKeys.value;
+            const validItemIds = allPersistableItemIds.value;
+
+            for (const key of [...collapsedSections]) {
+                if (!validSectionKeys.has(String(key))) collapsedSections.delete(key);
+            }
+            for (const id of [...expandedMerchants]) {
+                if (!validItemIds.has(String(id))) expandedMerchants.delete(id);
+            }
+            for (const key of Object.keys(sortConfig)) {
+                if (!validSectionKeys.has(String(key))) delete sortConfig[key];
+            }
+        }
+
+        function initUiState() {
+            const validSectionKeys = allPersistableSectionKeys.value;
+            const validItemIds = allPersistableItemIds.value;
+
+            collapsedSections.clear();
+            expandedMerchants.clear();
+            Object.keys(sortConfig).forEach(key => delete sortConfig[key]);
+
+            let state = null;
+            try {
+                const raw = localStorage.getItem(UI_STATE_KEY);
+                if (raw) state = JSON.parse(raw);
+            } catch {
+                state = null;
+            }
+
+            if (!state || typeof state !== 'object') {
+                validSectionKeys.forEach(key => collapsedSections.add(key));
+                applyDetailsViewMode('merchant');
+                includeNegativeTotals.value = false;
+                chartsCollapsed.value = false;
+                detailsCollapsed.value = false;
+                return;
+            }
+
+            const knownSectionKeys = new Set((state.knownSectionKeys || []).map(k => String(k)));
+            const savedCollapsedSectionKeys = new Set((state.collapsedSectionKeys || []).map(k => String(k)));
+
+            for (const key of validSectionKeys) {
+                if (!knownSectionKeys.has(key) || savedCollapsedSectionKeys.has(key)) {
+                    collapsedSections.add(key);
+                }
+            }
+
+            const knownItemIds = new Set((state.knownItemIds || []).map(id => String(id)));
+            const expandedItemIds = new Set((state.expandedItemIds || []).map(id => String(id)));
+            for (const id of validItemIds) {
+                if (knownItemIds.has(id) && expandedItemIds.has(id)) {
+                    expandedMerchants.add(id);
+                }
+            }
+
+            if (state.sortConfig && typeof state.sortConfig === 'object') {
+                for (const [key, cfg] of Object.entries(state.sortConfig)) {
+                    if (!validSectionKeys.has(String(key))) continue;
+                    const column = cfg?.column || 'total';
+                    const dir = cfg?.dir === 'asc' ? 'asc' : 'desc';
+                    sortConfig[key] = { column, dir };
+                }
+            }
+
+            applyDetailsViewMode(state.detailsViewMode);
+            includeNegativeTotals.value = !!state.includeNegativeTotals;
+            chartsCollapsed.value = !!state.chartsCollapsed;
+            detailsCollapsed.value = !!state.detailsCollapsed;
+            normalizeUiStateForCurrentData();
+        }
+
+        function resetUiSettings() {
+            try {
+                localStorage.removeItem(UI_STATE_KEY);
+            } catch {
+                // Ignore localStorage failures.
+            }
+            initUiState();
+            saveUiState();
+        }
+
         // ========== URL HASH ==========
 
         function filtersToHash() {
@@ -1666,7 +2555,7 @@ createApp({
                 history.replaceState(null, '', location.pathname);
                 return;
             }
-            const typeChar = { category: 'c', subcategory: 'sc', merchant: 'm', month: 'd', tag: 't', text: 's' };
+            const typeChar = { category: 'c', subcategory: 'sc', merchant: 'm', month: 'd', daterange: 'dr', tag: 't', text: 's' };
             const parts = activeFilters.value.map(f => {
                 const mode = f.mode === 'exclude' ? '-' : '+';
                 return `${mode}${typeChar[f.type]}:${encodeURIComponent(f.text)}`;
@@ -1677,7 +2566,7 @@ createApp({
         function hashToFilters() {
             const hash = location.hash.slice(1);
             if (!hash) return;
-            const typeMap = { c: 'category', sc: 'subcategory', m: 'merchant', d: 'month', t: 'tag', s: 'text' };
+            const typeMap = { c: 'category', sc: 'subcategory', m: 'merchant', d: 'month', dr: 'daterange', t: 'tag', s: 'text' };
             hash.split('&').forEach(part => {
                 const mode = part[0] === '-' ? 'exclude' : 'include';
                 const start = part[0] === '+' || part[0] === '-' ? 1 : 0;
@@ -1695,7 +2584,7 @@ createApp({
         // ========== CHARTS ==========
 
         function initCharts() {
-            // Monthly trend chart
+            // Cash flow trend chart (datasets are built per update so empty series drop out)
             if (monthlyChart.value) {
                 const ctx = monthlyChart.value.getContext('2d');
                 const labels = availableMonths.value.map(m => m.label);
@@ -1703,26 +2592,7 @@ createApp({
                     type: 'bar',
                     data: {
                         labels,
-                        datasets: [
-                            {
-                                label: 'Spending',
-                                data: [],
-                                backgroundColor: '#4facfe',
-                                borderRadius: 4
-                            },
-                            {
-                                label: 'Income',
-                                data: [],
-                                backgroundColor: '#00c9a7',
-                                borderRadius: 4
-                            },
-                            {
-                                label: 'Investment',
-                                data: [],
-                                backgroundColor: '#7c3aed',
-                                borderRadius: 4
-                            }
-                        ]
+                        datasets: []
                     },
                     options: {
                         responsive: true,
@@ -1742,7 +2612,7 @@ createApp({
                         onClick: (e, elements) => {
                             if (elements.length > 0) {
                                 const idx = elements[0].index;
-                                const month = availableMonths.value[idx];
+                                const month = monthlyChartMonths[idx];
                                 if (month) addFilter(month.key, 'month', month.label);
                             }
                         }
@@ -1759,7 +2629,7 @@ createApp({
                         labels: [],
                         datasets: [{
                             data: [],
-                            backgroundColor: CATEGORY_COLORS
+                            backgroundColor: []
                         }]
                     },
                     options: {
@@ -1769,13 +2639,6 @@ createApp({
                             legend: {
                                 position: 'right',
                                 labels: { boxWidth: 12, padding: 8 }
-                            }
-                        },
-                        onClick: (e, elements) => {
-                            if (elements.length > 0) {
-                                const idx = elements[0].index;
-                                const label = pieChartInstance.data.labels[idx];
-                                if (label) addFilter(label, 'category');
                             }
                         }
                     }
@@ -1798,18 +2661,7 @@ createApp({
                         plugins: {
                             legend: {
                                 position: 'top',
-                                labels: { boxWidth: 12, padding: 8 },
-                                onClick: (e, legendItem, legend) => {
-                                    // Add category filter when clicking legend
-                                    const category = legendItem.text;
-                                    if (category) addFilter(category, 'category');
-                                    // Also toggle visibility (default behavior)
-                                    const index = legendItem.datasetIndex;
-                                    const ci = legend.chart;
-                                    const meta = ci.getDatasetMeta(index);
-                                    meta.hidden = meta.hidden === null ? !ci.data.datasets[index].hidden : null;
-                                    ci.update();
-                                }
+                                labels: { boxWidth: 12, padding: 8 }
                             }
                         },
                         scales: {
@@ -1821,24 +2673,6 @@ createApp({
                                 ticks: {
                                     callback: v => formatCurrencyShort(v)
                                 }
-                            }
-                        },
-                        onClick: (e, elements) => {
-                            if (elements.length > 0) {
-                                const el = elements[0];
-                                const monthIndex = el.index;
-                                const datasetIndex = el.datasetIndex;
-
-                                // Get month from filtered months
-                                const monthsToShow = filteredMonthsForCharts.value;
-                                const month = monthsToShow[monthIndex];
-
-                                // Get category from dataset
-                                const category = categoryMonthChartInstance.data.datasets[datasetIndex]?.label;
-
-                                // Add both filters
-                                if (month) addFilter(month.key, 'month', month.label);
-                                if (category) addFilter(category, 'category');
                             }
                         }
                     }
@@ -1852,68 +2686,91 @@ createApp({
             const agg = chartAggregations.value;
             const monthsToShow = filteredMonthsForCharts.value;
 
-            // Update monthly trend (spending, income, and investment)
+            // Update cash flow trend. Months with nothing to plot (e.g. only transfers)
+            // are dropped so the axis doesn't carry empty columns, and series without
+            // data are left out entirely so they don't linger in the legend.
             if (monthlyChartInstance) {
-                const labels = monthsToShow.map(m => m.label);
-                const spendingData = monthsToShow.map(m => agg.spendingByMonth[m.key] || 0);
-                const incomeData = monthsToShow.map(m => agg.incomeByMonth[m.key] || 0);
-                const investmentData = monthsToShow.map(m => agg.investmentByMonth[m.key] || 0);
-                const maxVal = Math.max(...spendingData, ...incomeData, ...investmentData, 1);
-                monthlyChartInstance.data.labels = labels;
-                monthlyChartInstance.data.datasets[0].data = spendingData;
-                monthlyChartInstance.data.datasets[1].data = incomeData;
-                monthlyChartInstance.data.datasets[2].data = investmentData;
+                const CASH_FLOW_SERIES = [
+                    { label: 'Spending', byMonth: agg.spendingByMonth, color: '#4facfe' },
+                    { label: 'Income', byMonth: agg.incomeByMonth, color: '#00c9a7' },
+                    { label: 'Credits', byMonth: agg.creditsByMonth, color: '#ffa94d' },
+                    { label: 'Investment', byMonth: agg.investmentByMonth, color: '#7c3aed' }
+                ];
+
+                monthlyChartMonths = monthsToShow.filter(m =>
+                    CASH_FLOW_SERIES.some(s => (s.byMonth[m.key] || 0) > 0)
+                );
+
+                const datasets = [];
+                let maxVal = 1;
+                for (const series of CASH_FLOW_SERIES) {
+                    const data = monthlyChartMonths.map(m => series.byMonth[m.key] || 0);
+                    if (!data.some(v => v > 0)) continue;
+                    datasets.push({
+                        label: series.label,
+                        data,
+                        backgroundColor: series.color,
+                        borderRadius: 4
+                    });
+                    maxVal = Math.max(maxVal, ...data);
+                }
+
+                monthlyChartInstance.data.labels = monthlyChartMonths.map(m => m.label);
+                monthlyChartInstance.data.datasets = datasets;
                 monthlyChartInstance.options.scales.y.suggestedMax = maxVal * 1.1;
                 monthlyChartInstance.update();
             }
 
-            // Update category pie
+            // Both category charts share this ranking so their series and colors line up
+            const ranked = Object.entries(agg.byCategory)
+                .filter(([_, v]) => v > 0)
+                .sort((a, b) => b[1] - a[1])
+                .map(([name]) => name);
+            const topCategories = ranked.slice(0, TOP_CATEGORY_COUNT);
+            const otherCategories = ranked.slice(TOP_CATEGORY_COUNT);
+            const categoryColor = i => CATEGORY_COLORS[i % CATEGORY_COLORS.length];
+
+            // Update category pie (top N + "Other")
             if (pieChartInstance) {
-                const entries = Object.entries(agg.byCategory)
-                    .filter(([_, v]) => v > 0)
-                    .sort((a, b) => b[1] - a[1]);
-                pieChartInstance.data.labels = entries.map(e => e[0]);
-                pieChartInstance.data.datasets[0].data = entries.map(e => e[1]);
+                const labels = topCategories.slice();
+                const data = topCategories.map(cat => agg.byCategory[cat]);
+                const colors = topCategories.map((_, i) => categoryColor(i));
+
+                if (otherCategories.length > 0) {
+                    labels.push(OTHER_CATEGORY_LABEL);
+                    data.push(otherCategories.reduce((sum, cat) => sum + agg.byCategory[cat], 0));
+                    colors.push(OTHER_CATEGORY_COLOR);
+                }
+
+                pieChartInstance.data.labels = labels;
+                pieChartInstance.data.datasets[0].data = data;
+                pieChartInstance.data.datasets[0].backgroundColor = colors;
                 pieChartInstance.update();
             }
 
-            // Update category by month (top 8 spending categories + income + investment)
+            // Update category by month (top N + "Other"). Months without spending
+            // are dropped so the axis doesn't carry empty columns.
             if (categoryMonthChartInstance) {
-                const labels = monthsToShow.map(m => m.label);
-                const categories = Object.keys(agg.byCategoryByMonth).sort((a, b) => {
-                    const totalA = Object.values(agg.byCategoryByMonth[a]).reduce((s, v) => s + v, 0);
-                    const totalB = Object.values(agg.byCategoryByMonth[b]).reduce((s, v) => s + v, 0);
-                    return totalB - totalA;
-                }).slice(0, 8); // Top 8 spending categories
-
-                const datasets = categories.map((cat, i) => ({
+                const spendingMonths = monthsToShow.filter(m => (agg.spendingByMonth[m.key] || 0) > 0);
+                const labels = spendingMonths.map(m => m.label);
+                const datasets = topCategories.map((cat, i) => ({
                     label: cat,
-                    data: monthsToShow.map(m => agg.byCategoryByMonth[cat][m.key] || 0),
-                    backgroundColor: CATEGORY_COLORS[i % CATEGORY_COLORS.length]
+                    data: spendingMonths.map(m => agg.byCategoryByMonth[cat]?.[m.key] || 0),
+                    backgroundColor: categoryColor(i)
                 }));
 
-                // Add income as its own dataset (green, like monthly chart)
-                const incomeData = monthsToShow.map(m => agg.incomeByMonth[m.key] || 0);
-                if (incomeData.some(v => v > 0)) {
+                if (otherCategories.length > 0) {
                     datasets.push({
-                        label: 'Income',
-                        data: incomeData,
-                        backgroundColor: '#00c9a7'
-                    });
-                }
-
-                // Add investment as its own dataset (purple, like monthly chart)
-                const investmentData = monthsToShow.map(m => agg.investmentByMonth[m.key] || 0);
-                if (investmentData.some(v => v > 0)) {
-                    datasets.push({
-                        label: 'Investment',
-                        data: investmentData,
-                        backgroundColor: '#7c3aed'
+                        label: OTHER_CATEGORY_LABEL,
+                        data: spendingMonths.map(m => otherCategories.reduce(
+                            (sum, cat) => sum + (agg.byCategoryByMonth[cat]?.[m.key] || 0), 0
+                        )),
+                        backgroundColor: OTHER_CATEGORY_COLOR
                     });
                 }
 
                 // Calculate max for stacked bar (sum of all categories per month)
-                const monthTotals = monthsToShow.map((m, idx) =>
+                const monthTotals = spendingMonths.map((m, idx) =>
                     datasets.reduce((sum, ds) => sum + (ds.data[idx] || 0), 0)
                 );
                 const maxVal = Math.max(...monthTotals, 1); // At least 1 to avoid 0
@@ -1935,6 +2792,31 @@ createApp({
 
         watch(activeFilters, filtersToHash, { deep: true });
         watch(chartAggregations, updateCharts);
+        watch([currentView, groupByMode, hasSections], () => {
+            nextTick(() => applyTxnColumnProfile());
+        });
+        watch([currentView, groupByMode], saveUiState);
+        watch([chartsCollapsed, detailsCollapsed, includeNegativeTotals], saveUiState);
+        watch(
+            () => Array.from(collapsedSections).map(v => String(v)).sort(),
+            saveUiState
+        );
+        watch(
+            () => Array.from(expandedMerchants).map(v => String(v)).sort(),
+            saveUiState
+        );
+        watch(
+            () => JSON.stringify(sortConfig),
+            saveUiState
+        );
+        watch(allPersistableSectionKeys, () => {
+            normalizeUiStateForCurrentData();
+            saveUiState();
+        });
+        watch(allPersistableItemIds, () => {
+            normalizeUiStateForCurrentData();
+            saveUiState();
+        });
 
         // Track extra_field matches and auto-expand merchants
         watch(activeFilters, () => {
@@ -1963,16 +2845,27 @@ createApp({
         // ========== LIFECYCLE ==========
 
         onMounted(() => {
+            document.title = title.value;
             initTheme();
+            initUiState();
+            isHydratingUiState = false;
+            saveUiState();
 
             // Wait for next tick to ensure computed properties are ready
             nextTick(() => {
                 hashToFilters();
+                recomputeTxnColumnProfiles();
                 initCharts();
+                requestAnimationFrame(() => {
+                    requestAnimationFrame(() => {
+                        setAppReadyState();
+                    });
+                });
             });
 
             // Scroll handling
             window.addEventListener('scroll', handleScroll);
+            window.addEventListener('resize', recomputeTxnColumnsDebounced);
 
             // Close autocomplete on outside click
             document.addEventListener('click', e => {
@@ -1985,6 +2878,10 @@ createApp({
                     document.querySelectorAll('.match-info-popup.visible').forEach(p => {
                         p.classList.remove('visible');
                     });
+                }
+                // Close the date-filter popover on outside click
+                if (!e.target.closest('.date-filter-wrap')) {
+                    datePopoverOpen.value = false;
                 }
             });
 
@@ -2000,16 +2897,22 @@ createApp({
         return {
             // State
             activeFilters, expandedMerchants, extraFieldMatches, collapsedSections, searchQuery,
-            showAutocomplete, autocompleteIndex, isScrolled, isDarkTheme, chartsCollapsed, helpCollapsed,
-            currentView, groupByMode, sortConfig, includeNegativeTotals,
+            showAutocomplete, autocompleteIndex, isScrolled, isDarkTheme, chartsCollapsed,
+            currentView, groupByMode, sortConfig, includeNegativeTotals, detailsCollapsed, allCollapsed, detailsSummary,
             // Refs
             monthlyChart, categoryPieChart, categoryByMonthChart,
             // Computed
             spendingData, title, subtitle,
-            visibleSections, filteredCategoryView, positiveCategoryView, subcategoryGroupedView, creditMerchants, filteredSectionView, positiveSectionView, hasSections,
+            visibleSections, filteredCategoryView, positiveCategoryView, subcategoryGroupedView, creditMerchants, filteredSectionView, positiveSectionView, hasSections, negativeTotalsCount,
             sectionTotals, grandTotal, grossSpending, creditsTotal, uncategorizedTotal,
             numFilteredMonths, filteredAutocomplete, availableMonths,
             categoryColorMap, tagColor,
+            // Date filter popover
+            datePopoverOpen, pendingMonths, activeYearTab, customStart, customEnd,
+            yearTabs, thisLastPresets, activeYearMonths,
+            isDateItemActive, toggleDateItem, yearTabHasPending,
+            toggleDatePopover, closeDatePopover, clearPendingMonths,
+            applyDateFilters, clearAllDateFilters,
             // Cash flow, transfers, and investments
             incomeTotal, spendingTotal, dataCreditsTotal, cashFlow,
             transfersIn, transfersOut, transfersNet,
@@ -2020,14 +2923,15 @@ createApp({
             // All transactions section
             groupedTransactions, expandedTransactions,
             // Methods
-            addFilter, removeFilter, toggleFilterMode, clearFilters, addMonthFilter,
-            toggleExpand, toggleSection, toggleSort, sortedMerchants,
+            addFilter, removeFilter, toggleIncludeFilter, isIncludeFilterActive, toggleFilterMode, clearFilters, addMonthFilter,
+            toggleExpand, toggleSection, toggleSort, toggleAllSections, sortedMerchants,
             formatCurrency, formatDate, formatMonthLabel, formatPct, filterTypeChar,
             highlightDescription,
             onSearchInput, onSearchKeydown, selectAutocompleteItem,
-            toggleTheme
+            toggleTheme, resetUiSettings
         };
     }
 })
 .component('merchant-section', MerchantSection)
+.component('drill-calendar', DrillCalendar)
 .mount('#app');

--- a/src/tally/templates.py
+++ b/src/tally/templates.py
@@ -3,7 +3,7 @@ Starter template strings for tally init command.
 """
 
 STARTER_SETTINGS = '''# Tally Settings
-title: "{year} Spending Analysis"
+title: "Tally Spending Analysis"
 
 # Data sources - add your statement files here
 # Run: tally inspect <file> to auto-detect the format string
@@ -29,6 +29,13 @@ data_sources:
   #   file: data/exports/*.csv     # top-level glob
   # - name: All Exports (recursive)
   #   file: data/exports/**/*.csv  # recursive glob
+
+# Capture columns to surface in the report's transaction details popup.
+# Any name here that a source's format string captures - e.g. {{memo}} - is shown
+# when non-blank. Names a source does not capture are ignored, so this is safe to
+# leave on. Override per source with report_fields under that data source.
+report_fields:
+  - memo
 
 output_dir: output
 html_filename: spending_summary.html

--- a/tests/test_analyzer.py
+++ b/tests/test_analyzer.py
@@ -7,6 +7,8 @@ import os
 from datetime import date
 
 from tally.analyzer import parse_amount, analyze_transactions, export_json, export_csv, classify_by_sections
+from tally.analyzer import build_merchant_json
+from tally.commands.run import collect_source_names
 from tally.analyzer import parse_generic_csv as _parse_generic_csv
 from tally.parsers import SkippedRow, ParseResult, _detect_date_format
 from tally.format_parser import parse_format_string
@@ -273,6 +275,48 @@ class TestExportJson:
         assert 'total' in parsed['by_month']['2025-01']
         assert parsed['by_month']['2025-01']['total'] == 55.0
         assert parsed['by_month']['2025-02']['total'] == 25.0
+
+
+class TestReportJsonDeterminism:
+    """The report JSON is diffed against the previous run, so it must be reproducible."""
+
+    def test_pattern_tags_sorted_when_list(self):
+        """match_info['tags'] arrives as a list built from a set - sort it anyway."""
+        result = build_merchant_json('AMAZON', {
+            'match_info': {'pattern': 'AMAZON*', 'source': 'merchants.rules',
+                           'tags': ['zeta', 'alpha', 'mid']},
+        })
+
+        assert result['pattern']['tags'] == ['alpha', 'mid', 'zeta']
+
+    def test_pattern_tags_sorted_when_set(self):
+        """The path the dead isinstance guard used to cover."""
+        result = build_merchant_json('AMAZON', {
+            'match_info': {'pattern': 'AMAZON*', 'source': 'merchants.rules',
+                           'tags': {'zeta', 'alpha', 'mid'}},
+        })
+
+        assert result['pattern']['tags'] == ['alpha', 'mid', 'zeta']
+
+    def test_source_names_dedupe_preserves_declaration_order(self):
+        """Duplicate source names collapse without being reordered."""
+        data_sources = [
+            {'name': 'B', 'file': 'b1.csv'},
+            {'name': 'A', 'file': 'a.csv'},
+            {'name': 'B', 'file': 'b2.csv'},
+        ]
+
+        assert collect_source_names(data_sources) == ['B', 'A']
+
+    def test_source_names_excludes_supplemental(self):
+        """Supplemental sources produce no transactions, so they stay out of the subtitle."""
+        data_sources = [
+            {'name': 'B', 'file': 'b.csv'},
+            {'name': 'Orders', 'file': 'orders.csv', '_supplemental': True},
+            {'name': 'A', 'file': 'a.csv'},
+        ]
+
+        assert collect_source_names(data_sources) == ['B', 'A']
 
 
 class TestExportCsv:

--- a/tests/test_analyzer.py
+++ b/tests/test_analyzer.py
@@ -3145,3 +3145,131 @@ class TestReportDiff:
         assert "Netflix" in detailed
         assert "Amazon" in detailed
         assert "lost 'shopping'" in detailed
+
+
+class TestReportFields:
+    """Tests for the report_fields setting and blank extra_field suppression."""
+
+    def test_report_fields_promotes_capture(self):
+        """report_fields surfaces a CSV capture as extra_fields, skipping blanks."""
+        csv_content = """Date,Description,Memo,Amount
+11/26/2025,LOWES #02736,Any idea what this is?,-45.00
+11/24/2025,LOWES #02736,,-12.00
+"""
+        f = tempfile.NamedTemporaryFile(mode='w', suffix='.csv', delete=False)
+        try:
+            f.write(csv_content)
+            f.close()
+
+            format_spec = parse_format_string("{date:%m/%d/%Y},{description},{memo},{amount}")
+            format_spec.report_fields = ['memo']
+            txns = parse_generic_csv(f.name, format_spec, get_all_rules())
+
+            assert txns[0]['extra_fields'] == {'memo': 'Any idea what this is?'}
+            # Blank memo produces no extra_fields at all - no "+1" badge in the report
+            assert 'extra_fields' not in txns[1]
+        finally:
+            os.unlink(f.name)
+
+    def test_captures_not_promoted_without_report_fields(self):
+        """Captures stay rule-only (field.*) unless named in report_fields."""
+        csv_content = """Date,Description,Memo,Amount
+11/26/2025,LOWES #02736,Any idea what this is?,-45.00
+"""
+        f = tempfile.NamedTemporaryFile(mode='w', suffix='.csv', delete=False)
+        try:
+            f.write(csv_content)
+            f.close()
+
+            format_spec = parse_format_string("{date:%m/%d/%Y},{description},{memo},{amount}")
+            txns = parse_generic_csv(f.name, format_spec, get_all_rules())
+
+            assert 'extra_fields' not in txns[0]
+            assert txns[0]['field']['memo'] == 'Any idea what this is?'
+        finally:
+            os.unlink(f.name)
+
+    def test_report_fields_from_global_setting(self):
+        """Global report_fields applies to sources that capture the field."""
+        from tally.config_loader import resolve_source_format
+
+        source = resolve_source_format(
+            {'name': 'wf', 'format': '{date:%m/%d/%Y},{description},{memo},{amount}'},
+            report_fields=['memo'],
+        )
+        assert source['_format_spec'].report_fields == ['memo']
+
+    def test_global_report_fields_ignores_missing_field(self):
+        """A global report_fields naming a field this source lacks is not an error."""
+        from tally.config_loader import resolve_source_format
+
+        source = resolve_source_format(
+            {'name': 'amex', 'format': '{date:%m/%d/%Y},{description},{amount}'},
+            report_fields=['memo'],
+        )
+        assert source['_format_spec'].report_fields == []
+
+    def test_source_report_fields_rejects_missing_field(self):
+        """An explicit source-level report_fields typo fails loudly."""
+        from tally.config_loader import resolve_source_format
+
+        with pytest.raises(ValueError, match='not captured by the format string'):
+            resolve_source_format({
+                'name': 'wf',
+                'format': '{date:%m/%d/%Y},{description},{amount}',
+                'report_fields': ['memo'],
+            })
+
+
+class TestEmptyFieldDirectiveSuppression:
+    """field: directives evaluating to empty values should not create blank fields."""
+
+    def test_blank_field_directive_omitted(self):
+        """A field: capturing an empty memo yields no extra_fields entry."""
+        from tally.merchant_utils import get_all_rules, normalize_merchant, clear_engine_cache
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            rules_file = os.path.join(tmpdir, 'merchants.rules')
+            with open(rules_file, 'w') as f:
+                f.write("""
+[Lowes]
+match: contains("LOWES")
+category: Hardware
+field: memo = field.memo
+""")
+
+            clear_engine_cache()
+            rules = get_all_rules(rules_file)
+
+            _, _, _, with_memo = normalize_merchant(
+                "LOWES #02736", rules, amount=45.0,
+                field={'memo': 'Any idea what this is?'})
+            assert with_memo['extra_fields'] == {'memo': 'Any idea what this is?'}
+
+            _, _, _, blank_memo = normalize_merchant(
+                "LOWES #02736", rules, amount=12.0, field={'memo': ''})
+            assert 'extra_fields' not in blank_memo
+
+            clear_engine_cache()
+
+    def test_zero_field_directive_retained(self):
+        """Zero is a meaningful value and must survive the empty-value guard."""
+        from tally.merchant_utils import get_all_rules, normalize_merchant, clear_engine_cache
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            rules_file = os.path.join(tmpdir, 'merchants.rules')
+            with open(rules_file, 'w') as f:
+                f.write("""
+[Lowes]
+match: contains("LOWES")
+category: Hardware
+field: fee = 0
+""")
+
+            clear_engine_cache()
+            rules = get_all_rules(rules_file)
+
+            _, _, _, info = normalize_merchant("LOWES #02736", rules, amount=45.0)
+            assert info['extra_fields'] == {'fee': 0}
+
+            clear_engine_cache()

--- a/tests/test_analyzer.py
+++ b/tests/test_analyzer.py
@@ -3220,6 +3220,56 @@ class TestReportFields:
                 'report_fields': ['memo'],
             })
 
+    def test_bare_string_report_fields_is_one_name(self):
+        """`report_fields: memo` means the memo capture, not m/e/m/o."""
+        from tally.config_loader import resolve_source_format
+
+        source = resolve_source_format({
+            'name': 'wf',
+            'format': '{date:%m/%d/%Y},{description},{memo},{amount}',
+            'report_fields': 'memo',
+        })
+        assert source['_format_spec'].report_fields == ['memo']
+
+    def test_empty_report_fields_promotes_nothing(self):
+        """An empty `report_fields:` is None in YAML and must not be iterated."""
+        from tally.config_loader import resolve_source_format
+
+        source = resolve_source_format({
+            'name': 'wf',
+            'format': '{date:%m/%d/%Y},{description},{memo},{amount}',
+            'report_fields': None,
+        })
+        assert source['_format_spec'].report_fields == []
+
+    def test_report_fields_rejects_wrong_type(self):
+        """A mapping or a list of non-strings is named, not a TypeError later."""
+        from tally.config_loader import resolve_source_format
+
+        with pytest.raises(ValueError, match='must be a capture name or a list'):
+            resolve_source_format({
+                'name': 'wf',
+                'format': '{date:%m/%d/%Y},{description},{memo},{amount}',
+                'report_fields': {'memo': True},
+            })
+
+        with pytest.raises(ValueError, match='must be a capture name or a list'):
+            resolve_source_format({
+                'name': 'wf',
+                'format': '{date:%m/%d/%Y},{description},{memo},{amount}',
+                'report_fields': ['memo', 7],
+            })
+
+    def test_global_bare_string_report_fields(self):
+        """The same coercion applies to the settings.yaml top-level value."""
+        from tally.config_loader import resolve_source_format
+
+        source = resolve_source_format(
+            {'name': 'wf', 'format': '{date:%m/%d/%Y},{description},{memo},{amount}'},
+            report_fields='memo',
+        )
+        assert source['_format_spec'].report_fields == ['memo']
+
 
 class TestEmptyFieldDirectiveSuppression:
     """field: directives evaluating to empty values should not create blank fields."""

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -7,6 +7,166 @@ import os
 from pathlib import Path
 
 
+class TestGlobPatternSupport:
+    """Tests for wildcard/glob pattern support in data source file paths."""
+
+    def test_glob_pattern_matches_multiple_files(self):
+        """Glob pattern should match multiple CSV files."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config_dir = os.path.join(tmpdir, 'config')
+            data_dir = os.path.join(tmpdir, 'data')
+            os.makedirs(config_dir)
+            os.makedirs(data_dir)
+
+            # Create settings with glob pattern
+            with open(os.path.join(config_dir, 'settings.yaml'), 'w') as f:
+                f.write("""year: 2025
+data_sources:
+  - name: TestBank
+    file: data/test*.csv
+    format: "{date:%Y-%m-%d},{description},{amount}"
+""")
+
+            # Create multiple matching files
+            with open(os.path.join(data_dir, 'test-jan.csv'), 'w') as f:
+                f.write("date,description,amount\n")
+                f.write("2025-01-15,NETFLIX,-15.99\n")
+
+            with open(os.path.join(data_dir, 'test-feb.csv'), 'w') as f:
+                f.write("date,description,amount\n")
+                f.write("2025-02-15,SPOTIFY,-9.99\n")
+
+            result = subprocess.run(
+                ['uv', 'run', 'tally', 'run', '--format', 'summary', config_dir],
+                capture_output=True,
+                text=True
+            )
+            assert result.returncode == 0
+            # Should report transactions from 2 files
+            assert '2 files' in result.stdout
+            assert '2 transactions' in result.stdout
+
+    def test_glob_pattern_single_file_fallback(self):
+        """Single file path (no wildcards) should still work."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config_dir = os.path.join(tmpdir, 'config')
+            data_dir = os.path.join(tmpdir, 'data')
+            os.makedirs(config_dir)
+            os.makedirs(data_dir)
+
+            with open(os.path.join(config_dir, 'settings.yaml'), 'w') as f:
+                f.write("""year: 2025
+data_sources:
+  - name: TestBank
+    file: data/transactions.csv
+    format: "{date:%Y-%m-%d},{description},{amount}"
+""")
+
+            with open(os.path.join(data_dir, 'transactions.csv'), 'w') as f:
+                f.write("date,description,amount\n")
+                f.write("2025-01-15,TEST,-10.00\n")
+
+            result = subprocess.run(
+                ['uv', 'run', 'tally', 'run', '--format', 'summary', config_dir],
+                capture_output=True,
+                text=True
+            )
+            assert result.returncode == 0
+            assert 'TestBank: 1 transactions' in result.stdout
+            assert '1 transactions' in result.stdout
+
+    def test_glob_pattern_no_matches_shows_error(self):
+        """Glob pattern with no matches should show helpful message."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config_dir = os.path.join(tmpdir, 'config')
+            data_dir = os.path.join(tmpdir, 'data')
+            os.makedirs(config_dir)
+            os.makedirs(data_dir)
+
+            with open(os.path.join(config_dir, 'settings.yaml'), 'w') as f:
+                f.write("""year: 2025
+data_sources:
+  - name: TestBank
+    file: data/nonexistent*.csv
+    format: "{date:%Y-%m-%d},{description},{amount}"
+""")
+
+            result = subprocess.run(
+                ['uv', 'run', 'tally', 'run', '--format', 'summary', config_dir],
+                capture_output=True,
+                text=True
+            )
+            # Should report that no files matched the glob pattern
+            assert result.returncode == 1
+            assert 'No files matched' in result.stdout
+            assert 'data/nonexistent*.csv' in result.stdout
+
+    def test_glob_diag_shows_matched_files(self):
+        """Diag command should show matched files for glob patterns."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config_dir = os.path.join(tmpdir, 'config')
+            data_dir = os.path.join(tmpdir, 'data')
+            os.makedirs(config_dir)
+            os.makedirs(data_dir)
+
+            with open(os.path.join(config_dir, 'settings.yaml'), 'w') as f:
+                f.write("""year: 2025
+data_sources:
+  - name: TestBank
+    file: data/test*.csv
+    format: "{date:%Y-%m-%d},{description},{amount}"
+""")
+
+            # Create multiple matching files
+            with open(os.path.join(data_dir, 'test-a.csv'), 'w') as f:
+                f.write("date,description,amount\n")
+
+            with open(os.path.join(data_dir, 'test-b.csv'), 'w') as f:
+                f.write("date,description,amount\n")
+
+            result = subprocess.run(
+                ['uv', 'run', 'tally', 'diag', config_dir],
+                capture_output=True,
+                text=True
+            )
+            assert result.returncode == 0
+            # Should show the configured glob and resolved file count
+            assert 'data/test*.csv' in result.stdout
+            assert '(2 files)' in result.stdout
+
+    def test_glob_files_processed_in_sorted_order(self):
+        """Files should be processed in sorted order for consistency."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config_dir = os.path.join(tmpdir, 'config')
+            data_dir = os.path.join(tmpdir, 'data')
+            os.makedirs(config_dir)
+            os.makedirs(data_dir)
+
+            with open(os.path.join(config_dir, 'settings.yaml'), 'w') as f:
+                f.write("""year: 2025
+data_sources:
+  - name: TestBank
+    file: data/*.csv
+    format: "{date:%Y-%m-%d},{description},{amount}"
+""")
+
+            # Create files in non-alphabetical order
+            with open(os.path.join(data_dir, 'z-last.csv'), 'w') as f:
+                f.write("date,description,amount\n")
+                f.write("2025-01-01,Z_FIRST,-1.00\n")
+
+            with open(os.path.join(data_dir, 'a-first.csv'), 'w') as f:
+                f.write("date,description,amount\n")
+                f.write("2025-01-01,A_FIRST,-1.00\n")
+
+            # Resolver should return files in sorted order regardless of creation order
+            from tally.path_utils import resolve_data_source_paths
+
+            files, _ = resolve_data_source_paths(config_dir, 'data/*.csv')
+            basenames = [os.path.basename(f) for f in files]
+            assert basenames == ['a-first.csv', 'z-last.csv']
+
+
 class TestCLIErrorHandling:
     """Tests for helpful error messages when CLI is misused."""
 

--- a/tests/test_report_html.py
+++ b/tests/test_report_html.py
@@ -39,6 +39,27 @@ pytestmark = [
 ]
 
 
+@pytest.fixture(autouse=True)
+def _expand_categories_after_navigation(page: Page):
+    """Category sections default to collapsed on a fresh load ("Save Layout
+    Settings to Local Storage": no saved state means everything starts
+    collapsed). This suite predates that feature and assumes the old
+    expanded-by-default state, so expand everything after each navigation
+    instead of adding an expand step to every test.
+    """
+    original_goto = page.goto
+
+    def goto_and_expand(url, **kwargs):
+        response = original_goto(url, **kwargs)
+        toggle = page.get_by_test_id("collapse-all-toggle")
+        if toggle.get_attribute("title") == "Expand all categories":
+            toggle.click()
+        return response
+
+    page.goto = goto_and_expand
+    yield
+
+
 @pytest.fixture(scope="module")
 def report_path(tmp_path_factory):
     """Generate a test report with known fixture data.
@@ -183,8 +204,8 @@ class TestUINavigation:
         # Amazon has transactions on: Jan 5, Jan 10, Feb 1, Mar 1
         # Should be sorted descending: Mar 1, Feb 1, Jan 10, Jan 5
         assert len(dates) == 4, f"Expected 4 Amazon transactions, got {len(dates)}: {dates}"
-        # Verify descending order
-        assert dates == ["Mar 1", "Feb 1", "Jan 10", "Jan 5"], f"Expected descending order, got {dates}"
+        # Verify descending order (dates always include the year)
+        assert dates == ["Mar 1, 2024", "Feb 1, 2024", "Jan 10, 2024", "Jan 5, 2024"], f"Expected descending order, got {dates}"
 
     def test_tag_click_adds_filter(self, page: Page, report_path):
         """Clicking a tag adds it as a filter."""
@@ -321,6 +342,80 @@ class TestCalculationAccuracy:
 
         # Original total restored
         expect(page.get_by_test_id("filtered-amount")).to_contain_text("$1,031")
+
+
+# =============================================================================
+# Category 2b: Transaction Details container & collapse controls
+# =============================================================================
+
+class TestTransactionDetailsContainer:
+    """Tests for the Transaction Details container, header summary, and collapse controls."""
+
+    def test_container_and_summary_present(self, page: Page, report_path):
+        """The Transaction Details container renders with a view-aware count summary."""
+        page.goto(f"file://{report_path}")
+        expect(page.locator(".details-section > .section-header h2")).to_contain_text("Transaction Details")
+        # Merchant view (default): "N categories, N merchants"
+        expect(page.get_by_test_id("details-summary")).to_have_text("2 categories, 4 merchants")
+
+    def test_summary_updates_for_subcategory_view(self, page: Page, report_path):
+        """Switching to Subcategory view changes the count label wording."""
+        page.goto(f"file://{report_path}")
+        page.get_by_role("button", name="Subcategory", exact=True).click()
+        expect(page.get_by_test_id("details-summary")).to_contain_text("subcategories")
+
+    def test_collapse_all_hides_category_rows(self, page: Page, report_path):
+        """Collapse-all folds every category; the button flips to Expand."""
+        page.goto(f"file://{report_path}")
+        shopping = page.get_by_test_id("section-cat-Shopping")
+        expect(shopping).not_to_have_class(re.compile("is-collapsed"))
+        page.get_by_test_id("collapse-all-toggle").click()
+        expect(shopping).to_have_class(re.compile("is-collapsed"))
+        expect(page.get_by_test_id("collapse-all-toggle")).to_have_attribute("title", "Expand all categories")
+
+    def test_expand_all_reopens_categories(self, page: Page, report_path):
+        """Expand-all re-opens the category sections."""
+        page.goto(f"file://{report_path}")
+        toggle = page.get_by_test_id("collapse-all-toggle")
+        shopping = page.get_by_test_id("section-cat-Shopping")
+        toggle.click()  # collapse all
+        expect(shopping).to_have_class(re.compile("is-collapsed"))
+        toggle.click()  # expand all
+        expect(shopping).not_to_have_class(re.compile("is-collapsed"))
+
+    def test_collapse_all_folds_open_transactions_and_expand_leaves_them_folded(self, page: Page, report_path):
+        """Collapse-all folds open transaction lists; expand-all reopens categories only (txns stay folded)."""
+        page.goto(f"file://{report_path}")
+        page.get_by_test_id("merchant-row-Amazon").click()  # open transactions
+        expect(page.locator(".txn-row:has-text('AMAZON MARKETPLACE')").first).to_be_visible()
+        toggle = page.get_by_test_id("collapse-all-toggle")
+        toggle.click()  # collapse all -> also folds open transactions
+        toggle.click()  # expand all -> reopens categories only
+        expect(page.locator(".txn-row:has-text('AMAZON MARKETPLACE')").first).not_to_be_visible()
+
+    def test_container_collapses_to_header_only(self, page: Page, report_path):
+        """Clicking the container header collapses the whole details body (header only)."""
+        page.goto(f"file://{report_path}")
+        details_body = page.locator(".details-body")
+        expect(details_body).to_be_visible()
+        page.locator(".details-section > .section-header").click()
+        expect(details_body).not_to_be_visible()
+
+    def test_column_alignment(self, page: Page, report_path):
+        """Count column is centered; Total column is right-aligned."""
+        page.goto(f"file://{report_path}")
+        count_align = page.locator("td.count-col").first.evaluate("el => getComputedStyle(el).textAlign")
+        total_align = page.locator("td.money").first.evaluate("el => getComputedStyle(el).textAlign")
+        assert count_align == "center", f"Count column should be centered, got {count_align}"
+        assert total_align == "right", f"Total column should be right-aligned, got {total_align}"
+
+    def test_total_row_pinned_in_tfoot(self, page: Page, report_path):
+        """The total row lives in a <tfoot> and is sticky to the bottom of the scroll box."""
+        page.goto(f"file://{report_path}")
+        total_cell = page.locator("tfoot .total-row td").first
+        expect(total_cell).to_be_attached()
+        position = total_cell.evaluate("el => getComputedStyle(el).position")
+        assert position == "sticky", f"Total row cells should be sticky, got {position}"
 
 
 # =============================================================================
@@ -1510,16 +1605,16 @@ class TestGroupingToggle:
         expect(online_row).to_contain_text("1 merchant")
 
     def test_subcategory_filter_adds_correct_type(self, page: Page, report_path):
-        """Clicking subcategory name adds subcategory filter, not merchant filter."""
+        """Clicking the filter button on a subcategory row adds a subcategory filter, not a merchant filter."""
         page.goto(f"file://{report_path}")
 
         # Switch to subcategory mode
         page.locator(".view-toggle button", has_text="Subcategory").click()
 
-        # Click on the subcategory name (first cell) in Online row
+        # Click the filter button on the Online row
         shopping_section = page.get_by_test_id("section-cat-Shopping")
-        online_name = shopping_section.locator(".merchant-name", has_text="Online")
-        online_name.click()
+        online_row = shopping_section.locator("tr.merchant-row", has_text="Online")
+        online_row.locator(".merchant-filter-trigger").click()
 
         # Should have a subcategory filter chip (class contains 'subcategory')
         filter_chip = page.locator(".filter-chip.subcategory")
@@ -2125,3 +2220,365 @@ class TestTransformDirective:
 
         badge = txn_row.locator(".extra-fields-trigger")
         expect(badge).not_to_be_visible()
+
+
+# =============================================================================
+# Category 4: Multi-granularity Date Filter (Month / Quarter / Year / Custom)
+# and multi-year transaction row display.
+# =============================================================================
+
+@pytest.fixture(scope="module")
+def multiyear_report_path(tmp_path_factory):
+    """Report spanning 4 calendar years with a views_file that excludes several
+    merchants, for date-filter and multi-year-row tests.
+
+    Key fixture properties:
+    - views_file defines a Food-only view, so Shopping/Subscriptions merchants
+      match zero views and are absent from `sections` (Part 1 bug surface).
+    - April 2026 appears ONLY via Amazon (Shopping, excluded) -> its month would
+      vanish if availableMonths sourced from `sections`.
+    - Netflix has all 12 months of 2025 (enables a Year chip) plus 2026 months
+      (multi-year -> rows show the year).
+    - Target has only 2026 transactions (single-year -> rows show no year).
+    - Amazon adds 2023 and 2024 transactions so 4 years exist (year tabs cap 3).
+    """
+    tmp_dir = tmp_path_factory.mktemp("multiyear_test")
+    config_dir = tmp_dir / "config"
+    data_dir = tmp_dir / "data"
+    output_dir = tmp_dir / "output"
+    config_dir.mkdir()
+    data_dir.mkdir()
+    output_dir.mkdir()
+
+    rows = []
+    for mm in range(1, 13):  # Netflix: all 12 months of 2025
+        rows.append(f"{mm:02d}/05/2025,NETFLIX,15.99")
+    rows += [
+        "01/06/2026,NETFLIX,15.99",
+        "02/06/2026,NETFLIX,15.99",
+        "03/12/2025,WHOLE FOODS MARKET,100.00",   # Food (in-view)
+        "06/15/2026,WHOLE FOODS MARKET,120.00",   # Food (in-view), 2026
+        "01/15/2023,AMAZON MARKETPLACE,40.00",    # 2023 (year-tab cap)
+        "06/15/2024,AMAZON MARKETPLACE,50.00",    # 2024 (year-tab cap)
+        "04/10/2026,AMAZON MARKETPLACE,45.00",    # April 2026: unique + excluded
+        "05/20/2026,TARGET,60.00",                # Target single-year 2026
+        "07/22/2026,TARGET,70.00",
+    ]
+    csv_content = "Date,Description,Amount\n" + "\n".join(rows) + "\n"
+    (data_dir / "transactions.csv").write_text(csv_content)
+
+    (config_dir / "settings.yaml").write_text(
+        'title: "Tally Spending Analysis"\n\n'
+        "data_sources:\n"
+        "  - name: Test\n"
+        "    file: data/transactions.csv\n"
+        '    format: "{date},{description},{amount}"\n\n'
+        "merchants_file: config/merchants.rules\n"
+        "views_file: config/views.rules\n"
+    )
+    (config_dir / "merchants.rules").write_text(
+        "[Netflix]\nmatch: contains(\"NETFLIX\")\ncategory: Subscriptions\nsubcategory: Streaming\n\n"
+        "[Whole Foods]\nmatch: normalized(\"WHOLE FOODS\")\ncategory: Food\nsubcategory: Grocery\n\n"
+        "[Amazon]\nmatch: normalized(\"AMAZON\")\ncategory: Shopping\nsubcategory: Online\n\n"
+        "[Target]\nmatch: normalized(\"TARGET\")\ncategory: Shopping\nsubcategory: Retail\n"
+    )
+    (config_dir / "views.rules").write_text(
+        "[Food & Dining]\ndescription: Food spending\nfilter: category == \"Food\"\n"
+    )
+
+    report_file = output_dir / "report.html"
+    result = subprocess.run(
+        ["uv", "run", "tally", "run", "-o", str(report_file), str(config_dir)],
+        capture_output=True, text=True,
+        cwd=os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+    )
+    if result.returncode != 0:
+        pytest.fail(f"Failed to generate report: {result.stderr}")
+    return str(report_file)
+
+
+def _open_date_popover(page):
+    """Open the date filter popover and return once it is visible."""
+    page.get_by_test_id("date-filter-trigger").click()
+    expect(page.get_by_test_id("date-popover")).to_be_visible()
+
+
+def _chip_texts(page):
+    return page.locator("[data-testid='filter-chip'] .chip-text").all_text_contents()
+
+
+class TestDateFilter:
+    """Tests for the multi-granularity date-filter popover."""
+
+    def test_excluded_merchant_month_appears_in_grid(self, page: Page, multiyear_report_path):
+        """Part 1 regression: April 2026 exists only via Amazon (excluded from
+        every view). It must still appear in the month grid, not vanish."""
+        page.goto(f"file://{multiyear_report_path}")
+        _open_date_popover(page)
+        # Switch to the 2026 tab regardless of the machine's current year.
+        page.get_by_test_id("date-year-tab-2026").click()
+        expect(page.get_by_test_id("date-month-cell-2026-04")).to_be_visible()
+
+    def test_this_last_preset_rows_render(self, page: Page, multiyear_report_path):
+        """This/Last rows render all six presets."""
+        page.goto(f"file://{multiyear_report_path}")
+        _open_date_popover(page)
+        for tid in ["this-month", "this-quarter", "this-year",
+                    "last-month", "last-quarter", "last-year"]:
+            expect(page.get_by_test_id(f"date-preset-{tid}")).to_be_visible()
+
+    def test_year_tabs_capped_to_three_most_recent(self, page: Page, multiyear_report_path):
+        """Year tabs show only the 3 most recent data years (2024/2025/2026),
+        not the oldest (2023)."""
+        page.goto(f"file://{multiyear_report_path}")
+        _open_date_popover(page)
+        expect(page.get_by_test_id("date-year-tab-2026")).to_be_visible()
+        expect(page.get_by_test_id("date-year-tab-2025")).to_be_visible()
+        expect(page.get_by_test_id("date-year-tab-2024")).to_be_visible()
+        expect(page.get_by_test_id("date-year-tab-2023")).to_have_count(0)
+
+    def test_selecting_quarter_months_aggregates_to_quarter_chip(self, page: Page, multiyear_report_path):
+        """Selecting Jan+Feb+Mar 2025 in the grid aggregates to one Q1 2025 chip."""
+        page.goto(f"file://{multiyear_report_path}")
+        _open_date_popover(page)
+        page.get_by_test_id("date-year-tab-2025").click()
+        for mm in ("01", "02", "03"):
+            page.get_by_test_id(f"date-month-cell-2025-{mm}").click()
+        page.get_by_test_id("date-apply").click()
+        assert _chip_texts(page) == ["Q1 2025"]
+
+    def test_incremental_apply_collapses_to_quarter(self, page: Page, multiyear_report_path):
+        """Apply Jan+Feb as two month chips; reopen, add Mar; re-apply collapses
+        the three into a single Q1 2025 chip."""
+        page.goto(f"file://{multiyear_report_path}")
+        _open_date_popover(page)
+        page.get_by_test_id("date-year-tab-2025").click()
+        page.get_by_test_id("date-month-cell-2025-01").click()
+        page.get_by_test_id("date-month-cell-2025-02").click()
+        page.get_by_test_id("date-apply").click()
+        assert sorted(_chip_texts(page)) == ["Feb 2025", "Jan 2025"]
+
+        _open_date_popover(page)
+        page.get_by_test_id("date-year-tab-2025").click()
+        page.get_by_test_id("date-month-cell-2025-03").click()
+        page.get_by_test_id("date-apply").click()
+        assert _chip_texts(page) == ["Q1 2025"]
+
+    def test_selecting_full_year_aggregates_to_year_chip(self, page: Page, multiyear_report_path):
+        """Selecting all 12 months of 2025 collapses to a single 2025 chip."""
+        page.goto(f"file://{multiyear_report_path}")
+        _open_date_popover(page)
+        page.get_by_test_id("date-year-tab-2025").click()
+        for mm in range(1, 13):
+            page.get_by_test_id(f"date-month-cell-2025-{mm:02d}").click()
+        page.get_by_test_id("date-apply").click()
+        assert _chip_texts(page) == ["2025"]
+
+    def test_year_and_quarter_from_different_periods_union(self, page: Page, multiyear_report_path):
+        """A 2025 Year chip plus a custom 2026 range union (both present, and the
+        filtered total is non-zero rather than an empty AND)."""
+        page.goto(f"file://{multiyear_report_path}")
+        _open_date_popover(page)
+        page.get_by_test_id("date-year-tab-2025").click()
+        for mm in range(1, 13):
+            page.get_by_test_id(f"date-month-cell-2025-{mm:02d}").click()
+        # Custom range in 2026, independent of the 2025 months.
+        page.get_by_test_id("date-start-text").fill("1/1/2026")
+        page.get_by_test_id("date-start-text").blur()
+        page.get_by_test_id("date-end-text").fill("6/30/2026")
+        page.get_by_test_id("date-end-text").blur()
+        page.get_by_test_id("date-apply").click()
+
+        chips = _chip_texts(page)
+        assert "2025" in chips
+        assert any("2026" in c and "–" in c for c in chips), chips
+        # Union is non-empty (2025 Netflix + 2026 transactions both counted).
+        expect(page.get_by_test_id("filtered-amount")).not_to_contain_text("$0")
+
+    def test_drill_calendar_commits_day_and_filters(self, page: Page, multiyear_report_path):
+        """The Start drill calendar commits a day-precision date into its input,
+        and a start+end range produces a filtering daterange chip."""
+        page.goto(f"file://{multiyear_report_path}")
+        _open_date_popover(page)
+        # Open Start calendar (defaults to today's month) and pick the 15th.
+        page.get_by_test_id("date-start-cal-btn").click()
+        expect(page.get_by_test_id("date-start-cal")).to_be_visible()
+        page.get_by_test_id("date-start-day-15").click()
+        # Calendar closes and the text input reflects the committed date
+        # (formatted "Mon D, YYYY", so it contains ", ").
+        expect(page.get_by_test_id("date-start-cal")).to_have_count(0)
+        assert ", " in page.get_by_test_id("date-start-text").input_value()
+
+    def test_cross_year_custom_range_shows_year_on_both_ends(self, page: Page, multiyear_report_path):
+        """A custom range spanning two calendar years shows the year on both the
+        start and the end of the chip label."""
+        page.goto(f"file://{multiyear_report_path}")
+        _open_date_popover(page)
+        page.get_by_test_id("date-start-text").fill("12/15/2025")
+        page.get_by_test_id("date-start-text").blur()
+        page.get_by_test_id("date-end-text").fill("2/10/2026")
+        page.get_by_test_id("date-end-text").blur()
+        page.get_by_test_id("date-apply").click()
+        chips = _chip_texts(page)
+        assert chips == ["Dec 15, 2025 – Feb 10, 2026"], chips
+
+    def test_quarter_chip_label_restores_from_hash(self, page: Page, multiyear_report_path):
+        """A quarter range chip restored from the URL hash re-derives its Q label
+        (the case most likely to regress if getDisplayText isn't updated)."""
+        page.goto(f"file://{multiyear_report_path}#+d:2025-01..2025-03")
+        assert _chip_texts(page) == ["Q1 2025"]
+
+    def test_custom_range_rehydrates_into_popover(self, page: Page, multiyear_report_path):
+        """An applied daterange chip loads back into the Start/End widget when
+        the popover reopens."""
+        page.goto(f"file://{multiyear_report_path}#+dr:2026-01-01..2026-01-31")
+        assert _chip_texts(page) == ["Jan 1 – Jan 31, 2026"]
+        _open_date_popover(page)
+        assert page.get_by_test_id("date-start-text").input_value() == "Jan 1, 2026"
+        assert page.get_by_test_id("date-end-text").input_value() == "Jan 31, 2026"
+
+    def test_unedited_apply_keeps_custom_range(self, page: Page, multiyear_report_path):
+        """Regression: open the popover and Apply with no edits — the daterange
+        chip and the hash survive."""
+        page.goto(f"file://{multiyear_report_path}#+dr:2026-01-01..2026-01-31")
+        _open_date_popover(page)
+        page.get_by_test_id("date-apply").click()
+        assert _chip_texts(page) == ["Jan 1 – Jan 31, 2026"]
+        assert page.evaluate("location.hash") == "#+dr:2026-01-01..2026-01-31"
+
+    def test_months_and_custom_range_both_survive_unedited_apply(self, page: Page, multiyear_report_path):
+        """Month chips and a custom range coexist through a no-op reopen+Apply."""
+        page.goto(f"file://{multiyear_report_path}#+d:2025-01&+dr:2026-01-01..2026-01-31")
+        assert sorted(_chip_texts(page)) == ["Jan 1 – Jan 31, 2026", "Jan 2025"]
+        _open_date_popover(page)
+        page.get_by_test_id("date-apply").click()
+        assert sorted(_chip_texts(page)) == ["Jan 1 – Jan 31, 2026", "Jan 2025"]
+
+    def test_edited_range_replaces_old_chip(self, page: Page, multiyear_report_path):
+        """Editing the rehydrated range yields exactly one daterange chip."""
+        page.goto(f"file://{multiyear_report_path}#+dr:2026-01-01..2026-01-31")
+        _open_date_popover(page)
+        page.get_by_test_id("date-end-text").fill("2/15/2026")
+        page.get_by_test_id("date-end-text").blur()
+        page.get_by_test_id("date-apply").click()
+        assert _chip_texts(page) == ["Jan 1 – Feb 15, 2026"]
+
+    def test_removed_range_does_not_resurrect(self, page: Page, multiyear_report_path):
+        """Removing the chip clears the widget, so reopening + Apply doesn't
+        re-add the range."""
+        page.goto(f"file://{multiyear_report_path}#+dr:2026-01-01..2026-01-31")
+        page.get_by_test_id("filter-chip-remove").click()
+        _open_date_popover(page)
+        assert page.get_by_test_id("date-start-text").input_value() == ""
+        assert page.get_by_test_id("date-end-text").input_value() == ""
+        page.get_by_test_id("date-apply").click()
+        expect(page.locator("[data-testid='filter-chip']")).to_have_count(0)
+
+    def test_reversed_range_is_normalized_on_apply(self, page: Page, multiyear_report_path):
+        """End before Start still produces an ordered chip."""
+        page.goto(f"file://{multiyear_report_path}")
+        _open_date_popover(page)
+        page.get_by_test_id("date-start-text").fill("2/15/2026")
+        page.get_by_test_id("date-start-text").blur()
+        page.get_by_test_id("date-end-text").fill("1/1/2026")
+        page.get_by_test_id("date-end-text").blur()
+        page.get_by_test_id("date-apply").click()
+        assert _chip_texts(page) == ["Jan 1 – Feb 15, 2026"]
+
+    def test_malformed_range_hash_opens_empty_without_error(self, page: Page, multiyear_report_path):
+        """A hand-edited hash must not wedge the widget or throw."""
+        errors = []
+        page.on("pageerror", lambda e: errors.append(str(e)))
+        page.goto(f"file://{multiyear_report_path}#+dr:garbage")
+        _open_date_popover(page)
+        assert page.get_by_test_id("date-start-text").input_value() == ""
+        assert page.get_by_test_id("date-end-text").input_value() == ""
+        assert errors == [], errors
+
+    def test_clear_all_filters_wipes_and_closes(self, page: Page, multiyear_report_path):
+        """The footer 'Clear all filters' removes every chip and closes the popover."""
+        page.goto(f"file://{multiyear_report_path}#+d:2025-01..2025-12")
+        assert _chip_texts(page) == ["2025"]
+        _open_date_popover(page)
+        page.get_by_test_id("date-clear-all").click()
+        expect(page.get_by_test_id("date-popover")).to_have_count(0)
+        expect(page.locator("[data-testid='filter-chip']")).to_have_count(0)
+
+
+class TestMultiYearTransactionRows:
+    """Part 3: transaction rows always show the year, regardless of whether the merchant's list spans years."""
+
+    def test_multiyear_merchant_rows_show_year(self, page: Page, multiyear_report_path):
+        """Netflix spans 2025 and 2026, so its transaction rows include ', YYYY'."""
+        page.goto(f"file://{multiyear_report_path}")
+        page.get_by_test_id("merchant-row-Netflix").click()
+        page.wait_for_timeout(150)
+        dates = page.locator(".txn-row:has-text('NETFLIX') .txn-date").all_text_contents()
+        assert dates, "expected Netflix transaction rows"
+        assert all(", 20" in d for d in dates), dates
+
+    def test_single_year_merchant_rows_also_show_year(self, page: Page, multiyear_report_path):
+        """Target has only 2026 transactions, but rows still include ', YYYY' (year is always shown)."""
+        page.goto(f"file://{multiyear_report_path}")
+        page.get_by_test_id("merchant-row-Target").click()
+        page.wait_for_timeout(150)
+        dates = page.locator(".txn-row:has-text('TARGET') .txn-date").all_text_contents()
+        assert dates, "expected Target transaction rows"
+        assert all(", 20" in d for d in dates), dates
+
+
+@pytest.fixture(scope="module")
+def current_quarter_report_path(tmp_path_factory):
+    """Report whose only data is three transactions in the three months of the
+    current calendar quarter, so selecting them lights up the This Quarter pill
+    (coverage-based highlight) deterministically regardless of run date."""
+    import datetime
+    today = datetime.date.today()
+    q_start_month = ((today.month - 1) // 3) * 3 + 1
+    months = [q_start_month, q_start_month + 1, q_start_month + 2]
+
+    tmp_dir = tmp_path_factory.mktemp("current_quarter_test")
+    config_dir = tmp_dir / "config"
+    data_dir = tmp_dir / "data"
+    output_dir = tmp_dir / "output"
+    config_dir.mkdir()
+    data_dir.mkdir()
+    output_dir.mkdir()
+
+    rows = [f"{mm:02d}/10/{today.year},NETFLIX,15.99" for mm in months]
+    (data_dir / "transactions.csv").write_text("Date,Description,Amount\n" + "\n".join(rows) + "\n")
+    (config_dir / "settings.yaml").write_text(
+        'title: "Tally Spending Analysis"\n\n'
+        "data_sources:\n  - name: Test\n    file: data/transactions.csv\n"
+        '    format: "{date},{description},{amount}"\n\n'
+        "merchants_file: config/merchants.rules\n"
+    )
+    (config_dir / "merchants.rules").write_text(
+        "[Netflix]\nmatch: contains(\"NETFLIX\")\ncategory: Subscriptions\nsubcategory: Streaming\n"
+    )
+    report_file = output_dir / "report.html"
+    result = subprocess.run(
+        ["uv", "run", "tally", "run", "-o", str(report_file), str(config_dir)],
+        capture_output=True, text=True,
+        cwd=os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+    )
+    if result.returncode != 0:
+        pytest.fail(f"Failed to generate report: {result.stderr}")
+    return str(report_file), today.year, months
+
+
+class TestDateFilterCoverageHighlight:
+    """Coverage-based preset highlighting (no stored quarter/year flag)."""
+
+    def test_selecting_quarter_months_highlights_this_quarter(self, page: Page, current_quarter_report_path):
+        report_path, year, months = current_quarter_report_path
+        page.goto(f"file://{report_path}")
+        _open_date_popover(page)
+        page.get_by_test_id(f"date-year-tab-{year}").click()
+        # Before selecting, This Quarter is not active.
+        this_q = page.get_by_test_id("date-preset-this-quarter")
+        expect(this_q).not_to_have_class(re.compile(r"\bactive\b"))
+        for mm in months:
+            page.get_by_test_id(f"date-month-cell-{year}-{mm:02d}").click()
+        # All three of the quarter's months selected -> pill lights up.
+        expect(this_q).to_have_class(re.compile(r"\bactive\b"))

--- a/tests/test_report_title.py
+++ b/tests/test_report_title.py
@@ -1,0 +1,95 @@
+"""Tests for how the report title reaches the generated HTML.
+
+The title is interpolated into the static loading shell as markup and handed to
+the Vue app as data, which are two different escaping contexts. These tests pin
+down that split, and that a non-string YAML value survives the trip.
+"""
+import json
+import re
+
+import pytest
+
+from tally.report import write_summary_file_vue
+
+
+MINIMAL_STATS = {
+    'num_months': 1,
+    'by_merchant': {},
+    'income_total': 0,
+    'spending_total': 0,
+    'credits_total': 0,
+    'cash_flow': 0,
+    'transfers_in': 0,
+    'transfers_out': 0,
+    'transfers_net': 0,
+    'investment_total': 0,
+}
+
+
+def generate(tmp_path, **kwargs):
+    """Generate a report and return its HTML."""
+    out = tmp_path / 'report.html'
+    write_summary_file_vue(dict(MINIMAL_STATS), str(out), **kwargs)
+    generate.last_dir = tmp_path
+    return out.read_text(encoding='utf-8')
+
+
+def embedded_data(html):
+    """Pull window.spendingData back out of the last generated report.
+
+    Embedded reports carry it inline; --no-embedded-html writes it to a
+    sibling spending_data.js instead.
+    """
+    source = html
+    if 'window.spendingData' not in source:
+        source = (generate.last_dir / 'spending_data.js').read_text(encoding='utf-8')
+    match = re.search(r'window\.spendingData = (\{.*\});', source)
+    assert match, "spendingData assignment not found in report"
+    return json.loads(match.group(1))
+
+
+class TestReportTitle:
+    def test_title_is_used_in_shell_and_data(self, tmp_path):
+        html = generate(tmp_path, title='2025 Budget')
+
+        assert '<title>2025 Budget</title>' in html
+        assert embedded_data(html)['title'] == '2025 Budget'
+
+    def test_default_title_is_the_same_in_shell_and_data(self, tmp_path):
+        """The shell and the mounted app must not disagree about the name.
+
+        Previously the shell fell back to 'Tally Spending Analysis' while the
+        data carried None, so Vue mounted and renamed the report.
+        """
+        html = generate(tmp_path)
+
+        assert '<title>Tally Spending Analysis</title>' in html
+        assert embedded_data(html)['title'] == 'Tally Spending Analysis'
+
+    @pytest.mark.parametrize('embedded_html', [True, False])
+    def test_markup_in_title_is_escaped_in_the_shell(self, tmp_path, embedded_html):
+        """A title carrying markup must not become markup in the report."""
+        html = generate(
+            tmp_path,
+            title='</title><script>alert(1)</script>',
+            embedded_html=embedded_html,
+        )
+
+        # Neither the shell (escaped as markup) nor the embedded data script
+        # (where '</' would close the <script> element) may emit it verbatim.
+        assert '<script>alert(1)</script>' not in html
+        assert '&lt;script&gt;alert(1)&lt;/script&gt;' in html
+        assert embedded_data(html)['title'] == '</title><script>alert(1)</script>'
+
+    def test_non_string_title_is_coerced(self, tmp_path):
+        """`title: 2025` in YAML arrives as an int and must not raise."""
+        html = generate(tmp_path, title=2025)
+
+        assert '<title>2025</title>' in html
+        assert embedded_data(html)['title'] == '2025'
+
+    def test_empty_title_falls_back_to_default(self, tmp_path):
+        html = generate(tmp_path, title='')
+
+        assert '<title>Tally Spending Analysis</title>' in html
+        assert embedded_data(html)['title'] == 'Tally Spending Analysis'


### PR DESCRIPTION
Title: Date filtering, transaction details, and per-transaction tag classification [3/6]

> **[3/6]** Based on `feature/report-json-determinism` (#99).
> Merging this PR into `main` also lands #98 and #99 if not already merged.
> **This layer only:** [`feature/report-json-determinism...feature/ui-tweaks`](https://github.com/terryaney/OpenSource.tally/compare/feature/report-json-determinism...feature/ui-tweaks)

This PR fixes a data correctness bug in the HTML report and adds date filtering, transaction details, and layout polish.

Screenshots below are from simulated data — visual reference only.

## Data Correctness Fix

Charts, Filtered View totals, and Section View percentages previously classified transactions using `merchant.tags` (the union across all transactions for that merchant). One `income` or `transfer` transaction could misclassify every other transaction at the same merchant. This PR switches to per-transaction `txn.tags`, matching the Python-side KPI logic.

<img width="1121" height="1233" alt="image" src="https://github.com/user-attachments/assets/bdb17498-7aa4-437c-8dce-e9d473971a0a" />

## Changes

- Per-transaction tag classification for charts, Filtered View, and Section View percentages
- Month / Quarter / Year / Custom date filtering with URL hash persistence
- Collapsible Transaction Details with sticky headers and pinned totals
- Loading shell while Vue mounts
- `report_fields` config so captured fields like memo appear without per-rule passthroughs
- Layout preferences persisted in `localStorage` with a reset control
- Rule provenance popup improvements
- Starter title changed to `Tally Spending Analysis`

## Behavior changes

Calling these out explicitly — they change what the report *does*, not just how it looks, and they aren't obvious from the diff:

- **Chart clicks now toggle visibility instead of applying filters.** Clicking a category pie segment or a category-by-month bar no longer adds a category/date filter. This is deliberate, not a dropped handler. (#101 then reworks it further, making Spending by Category an explicit filter surface with tri-state legend chips.)
- **Available months now come from `categoryView`**, so a month is no longer lost just because its merchant was excluded from every configured view.
- **Section View percentages use a new denominator** — `filteredViewTotals.value.spending`, computed per transaction — instead of whole-merchant include/exclude decisions derived from merchant tag unions, which could drop ordinary spending from the denominator in mixed-tag datasets.
- **Blank captured fields no longer render**, so the phantom `+1 Memo` indicator is gone.
- **Rule `field:` directives that evaluate to empty now emit no field at all**, rather than a field with a blank value. A `field:` directive runs for every transaction its rule matches, so a merchant whose rule captures a memo previously attached an *empty* memo to every transaction that didn't have one — which is what produced a `+1` popup indicator on transactions with nothing in the popup. `0` and `False` are retained; only `None` and empty strings/lists/dicts are dropped. This affects the `+N` indicator, the dynamic `extra_fields` columns in CSV export, and report search — it does **not** affect rule matching, since `field.<name>` in a match expression reads captured columns from the data file, not values emitted by another rule's `field:` directive.

**Mobile:** this is a locally generated HTML file and I expect nearly all use to be desktop/large display. Several pre-existing mobile issues remain and are deliberately out of scope here.

### Added while addressing review feedback

- **Section percentages changed value.** The denominator moved to a spending-only basis (above) but the numerator stayed a raw sum, so a section holding income, investment or transfers divided one basis by the other and could exceed 100%. Sections and categories now carry a spending-only subtotal computed with the same per-transaction classification, and the section percentage uses it. The per-merchant percentage *inside* a category is unchanged — both its halves are raw totals, so it was already self-consistent.
- **An excluded date chip is no longer flipped to an inclusion.** The date popover edits include-mode filters only: it will not rehydrate an excluded month or range into the pending set, and Apply no longer replaces chips it does not own.
- **Dates the calendar does not have are rejected.** `2/31/2026`, month 13 and `99/99/2026` previously parsed and produced filter chips that could never match a transaction.
- **A malformed date range in the URL hash no longer hangs the report.** `#+dr:garbage..garbage` walked to the string `NaN-NaN`, which compares less than the malformed end value forever, growing an array without bound until the tab died.
- **`report_fields` is validated.** A bare `report_fields: memo` was iterated character by character and treated as four capture names; an empty `report_fields:` raised `TypeError`. A bare string is now accepted as the single name it plainly means, an empty value means none, and anything else is rejected by name.
- **The report title is escaped and coerced.** It reached both the loading shell's markup and the embedded `spendingData` script unescaped, and a non-string value such as `title: 2025` raised `TypeError`. The title is now resolved once and stored back onto `spendingData`, so the static shell and the mounted app can no longer disagree — previously an untitled report visibly renamed itself on mount, because the two fallbacks were different strings.

The `</` escaping applied to the embedded JSON covers every string in the payload, not just the title. Merchant descriptions come from user CSVs and had the same exposure, so this is not new to this branch.

## Date Filtering

<img alt="image" src="https://github.com/user-attachments/assets/b87f9eee-a2be-44f8-a596-86e95fb6291d" />

<img alt="image" src="https://github.com/user-attachments/assets/11b901a3-2e04-49b8-9e29-8fde1590c6ea" />

## Loading State

<img alt="image" src="https://github.com/user-attachments/assets/98497684-afab-4160-b93e-7162d10ec0d3" />

## Transaction Details

<img alt="image" src="https://github.com/user-attachments/assets/20774752-d03a-4655-9e77-9164478bb55c" />

<img alt="image" src="https://github.com/user-attachments/assets/66a47034-ed4b-4d9b-afd9-56a6a4a4acae" />

<img alt="image" src="https://github.com/user-attachments/assets/7c56f70b-c561-4484-9cb7-a2fe784597f8" />

<img alt="image" src="https://github.com/user-attachments/assets/9246e05c-3c2d-4e44-8cab-13a6a4cc4b5b" />

## Stack

| # | Branch | PR | Description | Diff |
|---|---|---|---|---|
| 1 | `feature/globbing-documentation` | #98 | Glob pattern docs and CLI tests | [from main](https://github.com/terryaney/OpenSource.tally/compare/main...feature/globbing-documentation) |
| 2 | `feature/report-json-determinism` | #99 | Deterministic report JSON | [from PR98](https://github.com/terryaney/OpenSource.tally/compare/feature/globbing-documentation...feature/report-json-determinism) · [from main](https://github.com/terryaney/OpenSource.tally/compare/main...feature/report-json-determinism) |
| **3** | **`feature/ui-tweaks`** | **#100** | **Date filter, transaction details, per-txn tags** | **[from PR99](https://github.com/terryaney/OpenSource.tally/compare/feature/report-json-determinism...feature/ui-tweaks) · [from main](https://github.com/terryaney/OpenSource.tally/compare/main...feature/ui-tweaks)** |
| 4 | `feature/charts-reimagined` | #101 | Reimagined charts and KPIs | [from PR100](https://github.com/terryaney/OpenSource.tally/compare/feature/ui-tweaks...feature/charts-reimagined) · [from main](https://github.com/terryaney/OpenSource.tally/compare/main...feature/charts-reimagined) |
| 5 | `feature/merchant-composite-keys` | #102 | Composite merchant keys | [from PR101](https://github.com/terryaney/OpenSource.tally/compare/feature/charts-reimagined...feature/merchant-composite-keys) · [from main](https://github.com/terryaney/OpenSource.tally/compare/main...feature/merchant-composite-keys) |
| 6 | `feature/categorization` | #103 | Categorization review file | [from PR102](https://github.com/terryaney/OpenSource.tally/compare/feature/merchant-composite-keys...feature/categorization) · [from main](https://github.com/terryaney/OpenSource.tally/compare/main...feature/categorization) |

Independent: [`feature/ci-repair`](https://github.com/terryaney/OpenSource.tally/compare/main...feature/ci-repair) — #97 — fixes fork PR builds.